### PR TITLE
PYL-21 update first name and last name of person

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ format:
 
 test:
 	coverage run --branch -m pytest
-	coverage report --fail-under=75
+	coverage report --fail-under=75 -m
 	
 venv: 
 	python3 -m venv .venv

--- a/src/pylms/__main__.py
+++ b/src/pylms/__main__.py
@@ -1,19 +1,47 @@
 #!/bin/env python3
 
 from sys import argv
-from pylms.pylms import list_persons, store_person
+from pylms.pylms import list_persons, store_person, update_person
 
 
 def main() -> None:
     argv_length = len(argv)
+
+    if argv_length == 1:
+        _command_list()
+        return
+
+    if argv[1].lower() == "update":
+        _command_update(argv_length)
+        return
+
+    _command_create(argv_length)
+
+
+def _command_list():
+    list_persons()
+
+
+def _command_create(argv_length):
+    if argv_length > 3:
+        print(f"Too many arguments ({argv_length - 1})")
+        return
+
     if argv_length == 2:
         store_person(firstname=argv[1])
-    elif argv_length == 3:
-        store_person(firstname=argv[1], lastname=argv[2])
-    elif argv_length > 3:
-        print(f"Too many arguments ({argv_length - 1})")
     else:
-        list_persons()
+        store_person(firstname=argv[1], lastname=argv[2])
+
+
+def _command_update(argv_length):
+    if argv_length > 3:
+        print(f"Too many arguments ({argv_length - 1})")
+        return
+
+    if argv_length == 3:
+        update_person(pattern=argv[2])
+    else:
+        print(f"Missing search pattern")
 
 
 if __name__ == "__main__":

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -47,7 +47,7 @@ def _interactive_select_person(pattern: str) -> Person | None:
         return persons[0]
 
     print("Input id of person to update:")
-    for person in persons:
+    for person in sorted(persons, key=lambda p: p.person_id):
         _print_person(person)
     print("CTRL+C to exit")
 

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -6,14 +6,117 @@ def list_persons() -> None:
     persons = storage.read_persons()
     if persons:
         for person in sorted(persons, key=lambda p: p.person_id):
-            created = person.created
-            print(
-                f"({person.person_id})",
-                person,
-                f"({created.year}-{created.month}-{created.day} {created.hour}-{created.minute}-{created.second})",
-            )
+            _print_person(person)
     else:
         print("No Person registered yet.")
+
+
+def _print_person(person):
+    created = person.created
+    print(
+        f"({person.person_id})",
+        person,
+        f"({created.year}-{created.month}-{created.day} {created.hour}-{created.minute}-{created.second})",
+    )
+
+
+def _interactive_person_id(valid_ids: list[int]) -> int:
+    if not valid_ids:
+        raise ValueError("valid_ids can not be empty.")
+
+    while True:
+        n = input()
+        try:
+            res = int(n)
+            if res not in valid_ids:
+                print("Not a valid id.")
+                continue
+
+            return res
+        except ValueError:
+            print("Not an integer.")
+
+
+def _interactive_select_person(pattern: str) -> Person | None:
+    persons = _search_person(pattern)
+    if not persons:
+        print("No match.")
+        return
+
+    if len(persons) == 1:
+        return persons[0]
+
+    print("Input id of person to update:")
+    for person in persons:
+        _print_person(person)
+    print("CTRL+C to exit")
+
+    person_id = _interactive_person_id([person.person_id for person in persons])
+    for person in persons:
+        if person.person_id == person_id:
+            return person
+
+    # should not happen
+    raise RuntimeError(f"id {person_id} does not exist in list of Persons")
+
+
+def _interactive_person_details() -> tuple[str, str | None]:
+    while True:
+        text = input()
+
+        words = text.split(" ")
+        if len(words) > 2:
+            print("Too many words.")
+            continue
+
+        if len(words) == 1:
+            return words[0], None
+        return words[0], words[1]
+
+
+def update_person(pattern: str) -> None:
+    person_to_update: Person = _interactive_select_person(pattern)
+    if not person_to_update:
+        return
+
+    print("Input new first name and last name to update:")
+    _print_person(person_to_update)
+    print("CTRL+C to exit")
+
+    firstname: str
+    lastname: str
+    firstname, lastname = _interactive_person_details()
+
+    persons = storage.read_persons()
+    for person in persons:
+        if person.person_id == person_to_update.person_id:
+            person.firstname = firstname
+            person.lastname = lastname
+    storage.store_persons(persons)
+
+
+def search_person(pattern: str) -> None:
+    for person in _search_person(pattern):
+        _print_person(person)
+
+
+def _search_person(pattern: str) -> list[Person]:
+    persons = storage.read_persons()
+
+    res = []
+    for person in persons:
+        if _search_match(pattern, person):
+            res.append(person)
+
+    return res
+
+
+def _search_match(pattern: str, person: Person) -> bool:
+    pattern = pattern.lower()
+    if person.lastname:
+        return pattern in person.lastname.lower() or pattern in person.firstname.lower()
+
+    return pattern in person.firstname.lower()
 
 
 def store_person(firstname: str) -> None:

--- a/tests/pylms/pylms_protected_test.py
+++ b/tests/pylms/pylms_protected_test.py
@@ -1,0 +1,107 @@
+from pylms.core import Person
+from pylms.pylms import _search_person, _interactive_person_id, _interactive_select_person
+from pytest import raises, mark
+from unittest.mock import patch, call
+
+
+@patch("pylms.pylms.storage")
+def test_search_person(mock_storage):
+    persons = [
+        Person(3, "Bob"),
+        Person(1, "Seb"),
+        Person(2, "MarioEb"),
+    ]
+    mock_storage.read_persons.return_value = persons
+
+    assert _search_person("bob") == [persons[0]]
+    assert _search_person("BOB") == [persons[0]]
+    assert _search_person("eb") == [persons[1], persons[2]]
+    assert _search_person("bob") == [persons[0]]
+    assert _search_person("foo") == []
+
+
+def test_interactive_person_id_sanity_check():
+    with raises(ValueError, match="valid_ids can not be empty."):
+        _interactive_person_id([])
+
+
+@patch("builtins.input")
+@mark.parametrize("valid_ids", [[1], [2, 1], [23, 7, 1, 2]])
+def test_interactive_person_straight_correct_input(mock_input, valid_ids):
+    mock_input.return_value = "1"
+
+    res = _interactive_person_id([2, 1])
+
+    assert res == 1
+
+
+@patch("builtins.print")
+@patch("pylms.pylms._search_person")
+def test_interactive_select_person_no_match(mock_search_person, mock_print):
+    mock_search_person.return_value = []
+
+    res = _interactive_select_person("p")
+
+    assert res is None
+    mock_search_person.assert_called_once_with("p")
+    assert mock_search_person.call_count == 1
+    mock_print.assert_called_once_with("No match.")
+    assert mock_print.call_count == 1
+
+
+@patch("builtins.print")
+@patch("pylms.pylms._search_person")
+def test_interactive_select_person_one_match(mock_search_person, mock_print):
+    person = Person(123, "John", "Wick")
+    mock_search_person.return_value = [person]
+
+    res = _interactive_select_person("p")
+
+    assert res == person
+    mock_search_person.assert_called_once_with("p")
+    assert mock_search_person.call_count == 1
+    assert mock_print.call_count == 0
+
+
+@patch("builtins.print")
+@patch("pylms.pylms._interactive_person_id")
+@patch("pylms.pylms._print_person")
+@patch("pylms.pylms._search_person")
+def test_interactive_select_person_several_matches(
+    mock_search_person, mock_print_person, mock_interactive_person_id, mock_print
+):
+    persons = [
+        Person(3, "Bob"),
+        Person(1, "Seb"),
+    ]
+    mock_search_person.return_value = persons
+    mock_interactive_person_id.return_value = 3
+
+    res = _interactive_select_person("p")
+
+    assert res == persons[0]
+    mock_search_person.assert_called_once_with("p")
+    assert mock_search_person.call_count == 1
+    assert mock_print.call_count == 2
+    mock_print.assert_has_calls([call("Input id of person to update:"), call("CTRL+C to exit")])
+    assert mock_print_person.call_count == 2
+    mock_print_person.assert_has_calls([call(persons[0]), call(persons[1])])
+    assert mock_interactive_person_id.call_count == 1
+    mock_interactive_person_id.assert_called_once_with([3, 1])
+
+
+@patch("builtins.print")
+@patch("pylms.pylms._interactive_person_id")
+@patch("pylms.pylms._search_person")
+def test_interactive_raise_runtime_error_if_interactive_person_id_returns_crap(
+    mock_search_person, mock_interactive_person_id, mock_print
+):
+    persons = [
+        Person(3, "Bob"),
+        Person(1, "Seb"),
+    ]
+    mock_search_person.return_value = persons
+    mock_interactive_person_id.return_value = 123
+
+    with raises(RuntimeError, match="id 123 does not exist in list of Persons"):
+        _interactive_select_person("p")

--- a/tests/pylms/pylms_protected_test.py
+++ b/tests/pylms/pylms_protected_test.py
@@ -85,7 +85,7 @@ def test_interactive_select_person_several_matches(
     assert mock_print.call_count == 2
     mock_print.assert_has_calls([call("Input id of person to update:"), call("CTRL+C to exit")])
     assert mock_print_person.call_count == 2
-    mock_print_person.assert_has_calls([call(persons[0]), call(persons[1])])
+    mock_print_person.assert_has_calls([call(persons[1]), call(persons[0])])
     assert mock_interactive_person_id.call_count == 1
     mock_interactive_person_id.assert_called_once_with([3, 1])
 


### PR DESCRIPTION
# WHAT

Allow to set a new first name and last name of a Person.

This is achieved by first searching for a person, selecting the one to update and finally input new first name and last name.

# HOW

`pylms update foo` to search for person(s) which first name and/or last name contains `foo` ignoring case

* if no match, display `No match` and exit
* if one match, display 
    ```
    Input new first name and last name to update:
    (2) John Doe (2024-4-16 13-11-44)
    CTRL+C to exit
    ````
* if more than one match, display, in increasing id order:
    ```
    Input id of Person to update:
    (2) John Doe (2024-4-16 13-11-44)
    (6) John Deer (2024-5-16 13-11-44) 
    CTRL+C to exit
    ```
    then display same message as when there is a single match