### PR TITLE
PYL-22 delete a person

### DIFF
--- a/src/pylms/__main__.py
+++ b/src/pylms/__main__.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 
 from sys import argv
-from pylms.pylms import list_persons, store_person, update_person
+from pylms.pylms import list_persons, store_person, update_person, delete_person
 
 
 def main() -> None:
@@ -15,14 +15,18 @@ def main() -> None:
         _command_update(argv_length)
         return
 
+    if argv[1].lower() == "delete":
+        _command_delete(argv_length)
+        return
+
     _command_create(argv_length)
 
 
-def _command_list():
+def _command_list() -> None:
     list_persons()
 
 
-def _command_create(argv_length):
+def _command_create(argv_length: int) -> None:
     if argv_length > 3:
         print(f"Too many arguments ({argv_length - 1})")
         return
@@ -33,13 +37,24 @@ def _command_create(argv_length):
         store_person(firstname=argv[1], lastname=argv[2])
 
 
-def _command_update(argv_length):
+def _command_update(argv_length: int) -> None:
     if argv_length > 3:
         print(f"Too many arguments ({argv_length - 1})")
         return
 
     if argv_length == 3:
         update_person(pattern=argv[2])
+    else:
+        print(f"Missing search pattern")
+
+
+def _command_delete(argv_length: int) -> None:
+    if argv_length > 3:
+        print(f"Too many arguments ({argv_length - 1})")
+        return
+
+    if argv_length == 3:
+        delete_person(pattern=argv[2])
     else:
         print(f"Missing search pattern")
 

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -133,3 +133,30 @@ def store_person(firstname: str, lastname: str = None) -> None:
     person = Person(person_id=id_generator.next_person_id(), firstname=firstname, lastname=lastname)
     print(f"Create Person {person}.")
     storage.store_persons([person] + persons)
+
+
+def _interactive_hit_enter():
+    while True:
+        s = input()
+
+        if len(s) == 0:
+            return
+
+        print("Just hit ENTER")
+        continue
+
+
+def delete_person(pattern: str) -> None:
+    person_to_delete: Person = _interactive_select_person(pattern)
+    if not person_to_delete:
+        return
+
+    print("Hit ENTER to delete:")
+    _print_person(person_to_delete)
+    print("CTRL+C to exit")
+
+    _interactive_hit_enter()
+
+    persons = storage.read_persons()
+    persons.remove(person_to_delete)
+    storage.store_persons(persons)

--- a/tests/pylms/pylms_protected_test.py
+++ b/tests/pylms/pylms_protected_test.py
@@ -1,5 +1,5 @@
 from pylms.core import Person
-from pylms.pylms import _search_person, _interactive_person_id, _interactive_select_person
+from pylms.pylms import _search_person, _interactive_person_id, _interactive_select_person, _interactive_hit_enter
 from pytest import raises, mark
 from unittest.mock import patch, call
 
@@ -27,7 +27,7 @@ def test_interactive_person_id_sanity_check():
 
 @patch("builtins.input")
 @mark.parametrize("valid_ids", [[1], [2, 1], [23, 7, 1, 2]])
-def test_interactive_person_straight_correct_input(mock_input, valid_ids):
+def test_interactive_person_id_straight_correct_input(mock_input, valid_ids):
     mock_input.return_value = "1"
 
     res = _interactive_person_id([2, 1])
@@ -105,3 +105,23 @@ def test_interactive_raise_runtime_error_if_interactive_person_id_returns_crap(
 
     with raises(RuntimeError, match="id 123 does not exist in list of Persons"):
         _interactive_select_person("p")
+
+
+@patch("builtins.input")
+def test_interactive_hit_enter_straight_correct_input(mock_input):
+    mock_input.return_value = ""
+
+    _interactive_hit_enter()
+
+    mock_input.assert_called_once_with()
+    assert mock_input.call_count == 1
+
+
+@patch("builtins.input")
+def test_interactive_hit_enter_incorrect_inputs(mock_input):
+    mock_input.side_effect = ["q", "12", "ENTER", ""]
+
+    _interactive_hit_enter()
+
+    mock_input.assert_has_calls([call(), call(), call(), call()])
+    assert mock_input.call_count == 4

--- a/tests/pylms/pymls_test.py
+++ b/tests/pylms/pymls_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pylms.core import Person
-from pylms.pylms import list_persons, store_person, search_person, update_person
+from pylms.pylms import list_persons, store_person, search_person, update_person, delete_person
 from unittest.mock import patch, call
 
 
@@ -195,3 +195,49 @@ def test_update_person_out_of_several(mock_select, mock_person_details, mock_sto
     assert mock_storage.read_persons.call_count == 1
     assert mock_storage.store_persons.call_count == 1
     mock_storage.store_persons.assert_called_once_with([person3, person1, Person(2, "donut", "acme")])
+
+
+@patch("builtins.print")
+@patch("pylms.pylms.storage")
+@patch("pylms.pylms._interactive_hit_enter")
+@patch("pylms.pylms._print_person")
+@patch("pylms.pylms._interactive_select_person")
+def test_delete_person(mock_select, mock_print_person, mock_hit_enter, mock_storage, mock_print):
+    person1 = Person(1, "foo", "bar")
+    person2 = Person(2, "foo", "bar")
+    person3 = Person(3, "foo", "bar")
+    mock_select.return_value = person3
+    mock_storage.read_persons.return_value = [person3, person2, person1]
+
+    delete_person("p")
+
+    mock_select.assert_called_once_with("p")
+    assert mock_select.call_count == 1
+    mock_print.assert_has_calls([call("Hit ENTER to delete:"), call("CTRL+C to exit")])
+    assert mock_print.call_count == 2
+    mock_print_person.assert_called_once_with(person3)
+    assert mock_print_person.call_count == 1
+    mock_hit_enter.assert_called_once_with()
+    assert mock_hit_enter.call_count == 1
+    mock_storage.read_persons.assert_called_once_with()
+    assert mock_storage.read_persons.call_count == 1
+    mock_storage.store_persons.assert_called_once_with([person2, person1])
+    assert mock_storage.store_persons.call_count == 1
+
+
+@patch("builtins.print")
+@patch("pylms.pylms.storage")
+@patch("pylms.pylms._interactive_hit_enter")
+@patch("pylms.pylms._print_person")
+@patch("pylms.pylms._interactive_select_person")
+def test_delete_person(mock_select, mock_print_person, mock_hit_enter, mock_storage, mock_print):
+    mock_select.return_value = None
+
+    delete_person("p")
+
+    mock_select.assert_called_once_with("p")
+    assert mock_select.call_count == 1
+    assert mock_print_person.call_count == 0
+    assert mock_hit_enter.call_count == 0
+    assert mock_storage.call_count == 0
+    assert mock_print.call_count == 0


### PR DESCRIPTION
# WHAT

Allow to delete a Person.

Example of use cases:
* remove duplicates
* clean up `persons.db`

# HOW

`pylms delete foo` to search for person(s) which first name and/or last name contains `foo` ignoring case

* if no match, display `No match` and exit
* if one match, display 
   ```
   Hit ENTER to delete:
   (2) John Doe (2024-4-16 13-11-44)
   CTRL+C to exit
   ```
* if more than one match, display, in increasing id order:
   ```
   Input id of Person to delete:
   (2) John Doe (2024-4-16 13-11-44)
   (6) John Deer (2024-5-16 13-11-44) 
   CTRL+C to exit
   ```
   then display same message as when there is a single match