### PR TITLE
PYL-23 hide call stack when KeyboardInterrupt is expected

### DIFF
--- a/src/pylms/__main__.py
+++ b/src/pylms/__main__.py
@@ -1,10 +1,17 @@
 #!/bin/env python3
 
 from sys import argv
-from pylms.pylms import list_persons, store_person, update_person, delete_person
+from pylms.pylms import list_persons, store_person, update_person, delete_person, ExitPyLMS
 
 
 def main() -> None:
+    try:
+        _read_and_execute_commands()
+    except ExitPyLMS:
+        pass
+
+
+def _read_and_execute_commands():
     argv_length = len(argv)
 
     if argv_length == 1:

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -2,6 +2,17 @@ from pylms import storage
 from pylms.core import Person, PersonIdGenerator
 
 
+class ExitPyLMS(BaseException):
+    pass
+
+
+def _input_or_exit_pylms():
+    try:
+        return input()
+    except KeyboardInterrupt:
+        raise ExitPyLMS()
+
+
 def list_persons() -> None:
     persons = storage.read_persons()
     if persons:
@@ -25,7 +36,8 @@ def _interactive_person_id(valid_ids: list[int]) -> int:
         raise ValueError("valid_ids can not be empty.")
 
     while True:
-        n = input()
+        n = _input_or_exit_pylms()
+
         try:
             res = int(n)
             if res not in valid_ids:
@@ -62,7 +74,7 @@ def _interactive_select_person(pattern: str) -> Person | None:
 
 def _interactive_person_details() -> tuple[str, str | None]:
     while True:
-        text = input()
+        text = _input_or_exit_pylms()
 
         words = text.split(" ")
         if len(words) > 2:
@@ -137,7 +149,7 @@ def store_person(firstname: str, lastname: str = None) -> None:
 
 def _interactive_hit_enter():
     while True:
-        s = input()
+        s = _input_or_exit_pylms()
 
         if len(s) == 0:
             return


### PR DESCRIPTION
# WHY

`PyLMS` expects user to use `CTRL+C` to abort a command. However, this displays the `KeyboardInterrupt` traceback, which is ugly

# WHAT

Capture `KeyboardInterrupt` and do not display any trace when `CTRL+C` is expected