### PR TITLE
PYL-24 save and display parent/enfant relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 
 # PyLMS
 persons.db
+relationships.db

--- a/src/pylms/__main__.py
+++ b/src/pylms/__main__.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 
 from sys import argv
-from pylms.pylms import list_persons, store_person, update_person, delete_person, ExitPyLMS
+from pylms.pylms import list_persons, store_person, update_person, delete_person, link_persons, ExitPyLMS
 
 
 def main() -> None:
@@ -11,7 +11,7 @@ def main() -> None:
         pass
 
 
-def _read_and_execute_commands():
+def _read_and_execute_commands() -> None:
     argv_length = len(argv)
 
     if argv_length == 1:
@@ -24,6 +24,10 @@ def _read_and_execute_commands():
 
     if argv[1].lower() == "delete":
         _command_delete(argv_length)
+        return
+
+    if argv[1].lower() == "link":
+        _command_link(argv_length)
         return
 
     _command_create(argv_length)
@@ -64,6 +68,14 @@ def _command_delete(argv_length: int) -> None:
         delete_person(pattern=argv[2])
     else:
         print(f"Missing search pattern")
+
+
+def _command_link(argv_length: int) -> None:
+    if argv_length < 4:
+        print(f"Too few arguments ({argv_length -1})")
+
+    natural_link_request = " ".join(argv[2:])
+    link_persons(natural_link_request)
 
 
 if __name__ == "__main__":

--- a/src/pylms/core.py
+++ b/src/pylms/core.py
@@ -46,3 +46,63 @@ class PersonIdGenerator:
         res = self.next_id
         self.next_id += 1
         return res
+
+
+class RelationshipDefinition:
+    def __init__(self, name: str, aliases: list[str] = None) -> None:
+        self._name: str = name
+        self._aliases: list[str] = [] if aliases is None else aliases[:]
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def aliases(self) -> list[str]:
+        return self._aliases
+
+    def __repr__(self) -> str:
+        return self._name
+
+
+parent_enfant = RelationshipDefinition(
+    name="Parent/Enfant",
+    aliases=[
+        "père de",
+        "mère de",
+        "fils de",
+        "fille de",
+        "parent de",
+        "enfant de",
+    ],
+)
+
+relationship_definitions = [
+    parent_enfant,
+]
+
+
+class Relationship:
+    def __init__(self, person_left: Person, person_right: Person, definition: RelationshipDefinition) -> None:
+        self._person_left: Person = person_left
+        self._person_right: Person = person_right
+        self._definition: RelationshipDefinition = definition
+
+    @property
+    def left(self) -> Person:
+        return self._person_left
+
+    @property
+    def right(self) -> Person:
+        return self._person_right
+
+    def applies_to(self, person: Person) -> bool:
+        return self._person_left == person or self._person_right == person
+
+    @property
+    def definition(self):
+        return self._definition
+
+
+def resolve_persons(persons: list[Person], relationships: list[Relationship]) -> list[(Person, list[Relationship])]:
+    return [(person, list(filter(lambda r: r.applies_to(person), relationships))) for person in persons]

--- a/src/pylms/storage.py
+++ b/src/pylms/storage.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 import json
 from pathlib import Path
-from pylms.core import Person
+from pylms.core import Person, Relationship, relationship_definitions
 
-file_name = "persons.db"
+persons_file_name = "persons.db"
+relationships_file_name = "relationships.db"
 
 
 class PersonEncoder(json.JSONEncoder):
@@ -34,16 +35,73 @@ def store_persons(persons: list[Person]) -> None:
     if not persons:
         raise ValueError("Can't store an empty list of Persons.")
 
-    with open(file_name, "w") as f:
+    with open(persons_file_name, "w") as f:
         f.write(json.dumps(persons, cls=PersonEncoder))
 
 
 def read_persons() -> list[Person]:
-    file = Path(file_name)
+    file = Path(persons_file_name)
     if file.exists():
         with file.open("r") as f:
             content = f.read()
             if content:
                 return [to_person(s) for s in json.loads(content)]
+
+    return []
+
+
+class RelationshipEncoder(json.JSONEncoder):
+    def default(self, o: any) -> any:
+        if isinstance(o, Relationship):
+            return {"left": o.left.person_id, "right": o.right.person_id, "definition": o.definition.name}
+        # Let the base class default method raise the TypeError
+        return super().default(o)
+
+
+def _to_relationship(o: dict, persons: list[Person]) -> Relationship | None:
+    field_names = ("left", "right", "definition")
+    if not all(field_name in o for field_name in field_names):
+        raise ValueError(f"Missing at least one field of {field_names}")
+
+    left_id = int(o["left"])
+    right_id = int(o["right"])
+    definition_name = o["definition"]
+
+    person_index = {person.person_id: person for person in persons}
+    if left_id not in person_index or right_id not in person_index:
+        print(f"Either person {left_id} or person {right_id} does not exist")
+        return None
+
+    definition_index = {definition.name: definition for definition in relationship_definitions}
+    if definition_name not in definition_index:
+        print(f"definition {definition_name} does not exist")
+        return None
+
+    return Relationship(
+        person_left=person_index[left_id],
+        person_right=person_index[right_id],
+        definition=definition_index[definition_name],
+    )
+
+
+def store_relationships(relationships: list[Relationship]) -> None:
+    if not relationships:
+        raise ValueError("Can't store an empty list of Relationships.")
+
+    with open(relationships_file_name, "w") as f:
+        f.write(json.dumps(relationships, cls=RelationshipEncoder))
+
+
+def read_relationships(persons: list[Person]) -> list[Relationship]:
+    if not persons:
+        raise ValueError("Persons can't be empty")
+
+    file = Path(relationships_file_name)
+    if file.exists():
+        with file.open("r") as f:
+            content = f.read()
+            if content:
+                res = [_to_relationship(s, persons) for s in json.loads(content)]
+                return list(filter(lambda t: t is not None, res))
 
     return []

--- a/tests/pylms/pylms_protected_test.py
+++ b/tests/pylms/pylms_protected_test.py
@@ -1,5 +1,7 @@
 from pylms.core import Person
+from pylms.core import RelationshipDefinition
 from pylms.pylms import _search_person, _interactive_person_id, _interactive_select_person, _interactive_hit_enter
+from pylms.pylms import _parse_nl_link_request
 from pytest import raises, mark
 from unittest.mock import patch, call
 
@@ -20,108 +22,154 @@ def test_search_person(mock_storage):
     assert _search_person("foo") == []
 
 
-def test_interactive_person_id_sanity_check():
-    with raises(ValueError, match="valid_ids can not be empty."):
-        _interactive_person_id([])
+class Test_interactive_person_id:
+
+    def test_sanity_check(self):
+        with raises(ValueError, match="valid_ids can not be empty."):
+            _interactive_person_id([])
+
+    @patch("builtins.input")
+    @mark.parametrize("valid_ids", [[1], [2, 1], [23, 7, 1, 2]])
+    def test_straight_correct_input(self, mock_input, valid_ids):
+        mock_input.return_value = "1"
+
+        res = _interactive_person_id([2, 1])
+
+        assert res == 1
 
 
-@patch("builtins.input")
-@mark.parametrize("valid_ids", [[1], [2, 1], [23, 7, 1, 2]])
-def test_interactive_person_id_straight_correct_input(mock_input, valid_ids):
-    mock_input.return_value = "1"
+class Test_interactive_select_person:
 
-    res = _interactive_person_id([2, 1])
+    @patch("builtins.print")
+    @patch("pylms.pylms._search_person")
+    def test_no_match(self, mock_search_person, mock_print):
+        mock_search_person.return_value = []
 
-    assert res == 1
+        res = _interactive_select_person("p")
 
+        assert res is None
+        mock_search_person.assert_called_once_with("p")
+        assert mock_search_person.call_count == 1
+        mock_print.assert_called_once_with("No match.")
+        assert mock_print.call_count == 1
 
-@patch("builtins.print")
-@patch("pylms.pylms._search_person")
-def test_interactive_select_person_no_match(mock_search_person, mock_print):
-    mock_search_person.return_value = []
+    @patch("builtins.print")
+    @patch("pylms.pylms._search_person")
+    def test_one_match(self, mock_search_person, mock_print):
+        person = Person(123, "John", "Wick")
+        mock_search_person.return_value = [person]
 
-    res = _interactive_select_person("p")
+        res = _interactive_select_person("p")
 
-    assert res is None
-    mock_search_person.assert_called_once_with("p")
-    assert mock_search_person.call_count == 1
-    mock_print.assert_called_once_with("No match.")
-    assert mock_print.call_count == 1
+        assert res == person
+        mock_search_person.assert_called_once_with("p")
+        assert mock_search_person.call_count == 1
+        assert mock_print.call_count == 0
 
+    @patch("builtins.print")
+    @patch("pylms.pylms._interactive_person_id")
+    @patch("pylms.pylms._print_person")
+    @patch("pylms.pylms._search_person")
+    def test_several_matches(self, mock_search_person, mock_print_person, mock_interactive_person_id, mock_print):
+        persons = [
+            Person(3, "Bob"),
+            Person(1, "Seb"),
+        ]
+        mock_search_person.return_value = persons
+        mock_interactive_person_id.return_value = 3
 
-@patch("builtins.print")
-@patch("pylms.pylms._search_person")
-def test_interactive_select_person_one_match(mock_search_person, mock_print):
-    person = Person(123, "John", "Wick")
-    mock_search_person.return_value = [person]
+        res = _interactive_select_person("p")
 
-    res = _interactive_select_person("p")
+        assert res == persons[0]
+        mock_search_person.assert_called_once_with("p")
+        assert mock_search_person.call_count == 1
+        assert mock_print.call_count == 2
+        mock_print.assert_has_calls([call("Input id of person to update:"), call("CTRL+C to exit")])
+        assert mock_print_person.call_count == 2
+        mock_print_person.assert_has_calls([call(persons[1]), call(persons[0])])
+        assert mock_interactive_person_id.call_count == 1
+        mock_interactive_person_id.assert_called_once_with([3, 1])
 
-    assert res == person
-    mock_search_person.assert_called_once_with("p")
-    assert mock_search_person.call_count == 1
-    assert mock_print.call_count == 0
+    @patch("builtins.print")
+    @patch("pylms.pylms._interactive_person_id")
+    @patch("pylms.pylms._search_person")
+    def test_interactive_raise_runtime_error_if_interactive_person_id_returns_crap(
+        self, mock_search_person, mock_interactive_person_id, mock_print
+    ):
+        persons = [
+            Person(3, "Bob"),
+            Person(1, "Seb"),
+        ]
+        mock_search_person.return_value = persons
+        mock_interactive_person_id.return_value = 123
 
-
-@patch("builtins.print")
-@patch("pylms.pylms._interactive_person_id")
-@patch("pylms.pylms._print_person")
-@patch("pylms.pylms._search_person")
-def test_interactive_select_person_several_matches(
-    mock_search_person, mock_print_person, mock_interactive_person_id, mock_print
-):
-    persons = [
-        Person(3, "Bob"),
-        Person(1, "Seb"),
-    ]
-    mock_search_person.return_value = persons
-    mock_interactive_person_id.return_value = 3
-
-    res = _interactive_select_person("p")
-
-    assert res == persons[0]
-    mock_search_person.assert_called_once_with("p")
-    assert mock_search_person.call_count == 1
-    assert mock_print.call_count == 2
-    mock_print.assert_has_calls([call("Input id of person to update:"), call("CTRL+C to exit")])
-    assert mock_print_person.call_count == 2
-    mock_print_person.assert_has_calls([call(persons[1]), call(persons[0])])
-    assert mock_interactive_person_id.call_count == 1
-    mock_interactive_person_id.assert_called_once_with([3, 1])
-
-
-@patch("builtins.print")
-@patch("pylms.pylms._interactive_person_id")
-@patch("pylms.pylms._search_person")
-def test_interactive_raise_runtime_error_if_interactive_person_id_returns_crap(
-    mock_search_person, mock_interactive_person_id, mock_print
-):
-    persons = [
-        Person(3, "Bob"),
-        Person(1, "Seb"),
-    ]
-    mock_search_person.return_value = persons
-    mock_interactive_person_id.return_value = 123
-
-    with raises(RuntimeError, match="id 123 does not exist in list of Persons"):
-        _interactive_select_person("p")
+        with raises(RuntimeError, match="id 123 does not exist in list of Persons"):
+            _interactive_select_person("p")
 
 
-@patch("builtins.input")
-def test_interactive_hit_enter_straight_correct_input(mock_input):
-    mock_input.return_value = ""
+class Test_interactive_hit_enter:
 
-    _interactive_hit_enter()
+    @patch("builtins.input")
+    def test_interactive_hit_enter_straight_correct_input(self, mock_input):
+        mock_input.return_value = ""
 
-    mock_input.assert_called_once_with()
-    assert mock_input.call_count == 1
+        _interactive_hit_enter()
+
+        mock_input.assert_called_once_with()
+        assert mock_input.call_count == 1
+
+    @patch("builtins.input")
+    def test_interactive_hit_enter_incorrect_inputs(self, mock_input):
+        mock_input.side_effect = ["q", "12", "ENTER", ""]
+
+        _interactive_hit_enter()
+
+        mock_input.assert_has_calls([call(), call(), call(), call()])
+        assert mock_input.call_count == 4
 
 
-@patch("builtins.input")
-def test_interactive_hit_enter_incorrect_inputs(mock_input):
-    mock_input.side_effect = ["q", "12", "ENTER", ""]
+relationship_definition_1 = RelationshipDefinition(name="foo", aliases=["aaa", "bbb", "ccc"])
+relationship_definition_2 = RelationshipDefinition(name="bar", aliases=["11", "22", "33"])
+relationship_definition_3 = RelationshipDefinition(name="acme", aliases=["a2", "b3", "c4"])
 
-    _interactive_hit_enter()
 
-    mock_input.assert_has_calls([call(), call(), call(), call()])
-    assert mock_input.call_count == 4
+class Test_parse_nl_link_request:
+
+    @patch("pylms.pylms.relationship_definitions", [relationship_definition_1])
+    @mark.parametrize(
+        "nl_request, alias",
+        [
+            (s.format(f=alias), alias)
+            for s in ["donut {f} acme", "donut{f}acme", " donut {f} acme"]
+            for alias in relationship_definition_1.aliases
+        ],
+    )
+    def test_parse_the_right_alias_and_strip_person_patterns(self, nl_request, alias):
+        link_request = _parse_nl_link_request(nl_request)
+
+        assert link_request.left_person_pattern == "donut"
+        assert link_request.right_person_pattern == "acme"
+        assert link_request.definition == relationship_definition_1
+        assert link_request.alias == alias
+
+    @patch(
+        "pylms.pylms.relationship_definitions",
+        [relationship_definition_2, relationship_definition_1, relationship_definition_3],
+    )
+    @mark.parametrize(
+        "alias, expected_definition",
+        [("aaa", relationship_definition_1), ("c4", relationship_definition_3), ("33", relationship_definition_2)],
+    )
+    def test_select_the_right_definition_from_alias(self, alias, expected_definition):
+        link_request = _parse_nl_link_request(f"Johan {alias} Peter")
+
+        assert link_request.alias == alias
+        assert link_request.definition == expected_definition
+
+    @patch(
+        "pylms.pylms.relationship_definitions",
+        [relationship_definition_2, relationship_definition_1, relationship_definition_3],
+    )
+    @mark.parametrize("nl_request", ["aaa acme", "aaa", " aaa ", "fooaaa", "foo aaa"])
+    def test_return_none_if_missing_person_patterns(self, nl_request):
+        assert _parse_nl_link_request(nl_request) is None

--- a/tests/pylms/pymls_test.py
+++ b/tests/pylms/pymls_test.py
@@ -1,81 +1,80 @@
 from datetime import datetime
 from pylms.core import Person
-from pylms.pylms import list_persons, store_person, search_person, update_person, delete_person
+from pylms.pylms import list_persons, store_person, search_person, update_person, delete_person, link_persons
 from unittest.mock import patch, call
 
 
-@patch("builtins.print")
-@patch("pylms.pylms.storage.read_persons")
-@patch("pylms.pylms.storage.store_persons")
-def test_store_person_no_existing_person(mock_store_persons, mock_read_persons, mock_print):
-    firstname = "John"
-    lastname = "Doe"
-    mock_read_persons.return_value = []
+class Test_store_person:
 
-    store_person(firstname=firstname, lastname=lastname)
+    @patch("builtins.print")
+    @patch("pylms.pylms.storage.read_persons")
+    @patch("pylms.pylms.storage.store_persons")
+    def test_no_existing_person(self, mock_store_persons, mock_read_persons, mock_print):
+        firstname = "John"
+        lastname = "Doe"
+        mock_read_persons.return_value = []
 
-    mock_read_persons.assert_called_with()
-    assert mock_read_persons.call_count == 1
-    mock_store_persons.assert_called_with([Person(0, firstname=firstname, lastname=lastname)])
-    assert mock_store_persons.call_count == 1
-    mock_print.assert_called_with(f"Create Person {firstname} {lastname}.")
-    assert mock_print.call_count == 1
+        store_person(firstname=firstname, lastname=lastname)
 
+        mock_read_persons.assert_called_with()
+        assert mock_read_persons.call_count == 1
+        mock_store_persons.assert_called_with([Person(0, firstname=firstname, lastname=lastname)])
+        assert mock_store_persons.call_count == 1
+        mock_print.assert_called_with(f"Create Person {firstname} {lastname}.")
+        assert mock_print.call_count == 1
 
-@patch("builtins.print")
-@patch("pylms.pylms.storage.read_persons")
-@patch("pylms.pylms.storage.store_persons")
-def test_store_person_only_firstname_and_add_to_existing_persons(mock_store_persons, mock_read_persons, mock_print):
-    firstname = "Mike"
-    lastname = "Jagger"
-    persons = [Person(7, "Richard", "Brownsome")]
+    @patch("builtins.print")
+    @patch("pylms.pylms.storage.read_persons")
+    @patch("pylms.pylms.storage.store_persons")
+    def test_only_firstname_and_add_to_existing_persons(self, mock_store_persons, mock_read_persons, mock_print):
+        firstname = "Mike"
+        lastname = "Jagger"
+        persons = [Person(7, "Richard", "Brownsome")]
 
-    mock_read_persons.return_value = persons
+        mock_read_persons.return_value = persons
 
-    store_person(firstname=firstname, lastname=lastname)
+        store_person(firstname=firstname, lastname=lastname)
 
-    mock_read_persons.assert_called_with()
-    assert mock_read_persons.call_count == 1
-    mock_store_persons.assert_called_with([Person(8, firstname=firstname, lastname=lastname)] + persons)
-    assert mock_store_persons.call_count == 1
-    mock_print.assert_called_with(f"Create Person {firstname} {lastname}.")
-    assert mock_print.call_count == 1
+        mock_read_persons.assert_called_with()
+        assert mock_read_persons.call_count == 1
+        mock_store_persons.assert_called_with([Person(8, firstname=firstname, lastname=lastname)] + persons)
+        assert mock_store_persons.call_count == 1
+        mock_print.assert_called_with(f"Create Person {firstname} {lastname}.")
+        assert mock_print.call_count == 1
 
+    @patch("builtins.print")
+    @patch("pylms.pylms.storage.read_persons")
+    @patch("pylms.pylms.storage.store_persons")
+    def test_only_firstname_no_existing_person(self, mock_store_persons, mock_read_persons, mock_print):
+        firstname = "John"
+        mock_read_persons.return_value = []
 
-@patch("builtins.print")
-@patch("pylms.pylms.storage.read_persons")
-@patch("pylms.pylms.storage.store_persons")
-def test_store_person_only_firstname_no_existing_person(mock_store_persons, mock_read_persons, mock_print):
-    firstname = "John"
-    mock_read_persons.return_value = []
+        store_person(firstname=firstname)
 
-    store_person(firstname=firstname)
+        mock_read_persons.assert_called_with()
+        assert mock_read_persons.call_count == 1
+        mock_store_persons.assert_called_with([Person(person_id=0, firstname=firstname)])
+        assert mock_store_persons.call_count == 1
+        mock_print.assert_called_with(f"Create Person {firstname}.")
+        assert mock_print.call_count == 1
 
-    mock_read_persons.assert_called_with()
-    assert mock_read_persons.call_count == 1
-    mock_store_persons.assert_called_with([Person(person_id=0, firstname=firstname)])
-    assert mock_store_persons.call_count == 1
-    mock_print.assert_called_with(f"Create Person {firstname}.")
-    assert mock_print.call_count == 1
+    @patch("builtins.print")
+    @patch("pylms.pylms.storage.read_persons")
+    @patch("pylms.pylms.storage.store_persons")
+    def test_only_firstname_and_add_to_existing_persons(self, mock_store_persons, mock_read_persons, mock_print):
+        firstname = "John"
+        persons = [Person(2, "Paul", "Valérie")]
 
+        mock_read_persons.return_value = persons
 
-@patch("builtins.print")
-@patch("pylms.pylms.storage.read_persons")
-@patch("pylms.pylms.storage.store_persons")
-def test_store_person_only_firstname_and_add_to_existing_persons(mock_store_persons, mock_read_persons, mock_print):
-    firstname = "John"
-    persons = [Person(2, "Paul", "Valérie")]
+        store_person(firstname=firstname)
 
-    mock_read_persons.return_value = persons
-
-    store_person(firstname=firstname)
-
-    mock_read_persons.assert_called_with()
-    assert mock_read_persons.call_count == 1
-    mock_store_persons.assert_called_with([Person(3, firstname=firstname)] + persons)
-    assert mock_store_persons.call_count == 1
-    mock_print.assert_called_with(f"Create Person {firstname}.")
-    assert mock_print.call_count == 1
+        mock_read_persons.assert_called_with()
+        assert mock_read_persons.call_count == 1
+        mock_store_persons.assert_called_with([Person(3, firstname=firstname)] + persons)
+        assert mock_store_persons.call_count == 1
+        mock_print.assert_called_with(f"Create Person {firstname}.")
+        assert mock_print.call_count == 1
 
 
 @patch("builtins.print")
@@ -94,9 +93,12 @@ def test_list_persons_empty_storage(mock_store_persons, mock_read_persons, mock_
 
 
 @patch("builtins.print")
+@patch("pylms.pylms.storage.read_relationships", return_value=[])
 @patch("pylms.pylms.storage.read_persons")
 @patch("pylms.pylms.storage.store_persons")
-def test_list_persons_non_empty_storage(mock_store_persons, mock_read_persons, mock_print):
+def test_list_persons_persons_but_no_relationships(
+    mock_store_persons, mock_read_persons, mock_read_relationships, mock_print
+):
     t1 = datetime(2024, 4, 5, 12, 41, 58)
     t2 = datetime(2024, 9, 18, 21, 8, 8)
     persons = [
@@ -150,94 +152,113 @@ def test_search_person_results(mock_search_person, mock_print_persons):
     mock_print_persons.assert_has_calls([call(person) for person in persons])
 
 
-@patch("pylms.pylms.storage")
-@patch("pylms.pylms._interactive_select_person")
-def test_update_no_person_selected(mock_select, mock_storage):
-    mock_select.return_value = None
+class Test_update_person:
 
-    update_person("p")
+    @patch("pylms.pylms.storage")
+    @patch("pylms.pylms._interactive_select_person")
+    def test_no_person_selected(self, mock_select, mock_storage):
+        mock_select.return_value = None
 
-    mock_select.assert_called_once_with("p")
-    assert mock_storage.store_persons.call_count == 0
+        update_person("p")
 
+        mock_select.assert_called_once_with("p")
+        assert mock_storage.store_persons.call_count == 0
 
-@patch("pylms.pylms.storage")
-@patch("pylms.pylms._interactive_person_details")
-@patch("pylms.pylms._interactive_select_person")
-def test_update_single_person(mock_select, mock_person_details, mock_storage):
-    person = Person(1, "foo", "bar")
-    mock_select.return_value = person
-    mock_person_details.return_value = ("donut", "acme")
-    mock_storage.read_persons.return_value = [person]
+    @patch("pylms.pylms.storage")
+    @patch("pylms.pylms._interactive_person_details")
+    @patch("pylms.pylms._interactive_select_person")
+    def test_single_person(self, mock_select, mock_person_details, mock_storage):
+        person = Person(1, "foo", "bar")
+        mock_select.return_value = person
+        mock_person_details.return_value = ("donut", "acme")
+        mock_storage.read_persons.return_value = [person]
 
-    update_person("p")
+        update_person("p")
 
-    mock_select.assert_called_once_with("p")
-    assert mock_storage.read_persons.call_count == 1
-    assert mock_storage.store_persons.call_count == 1
-    mock_storage.store_persons.assert_called_once_with([Person(1, "donut", "acme")])
+        mock_select.assert_called_once_with("p")
+        assert mock_storage.read_persons.call_count == 1
+        assert mock_storage.store_persons.call_count == 1
+        mock_storage.store_persons.assert_called_once_with([Person(1, "donut", "acme")])
 
+    @patch("pylms.pylms.storage")
+    @patch("pylms.pylms._interactive_person_details")
+    @patch("pylms.pylms._interactive_select_person")
+    def test_out_of_several(self, mock_select, mock_person_details, mock_storage):
+        person1 = Person(1, "foo", "bar")
+        person2 = Person(2, "foo", "bar")
+        person3 = Person(3, "foo", "bar")
+        mock_select.return_value = person2
+        mock_person_details.return_value = ("donut", "acme")
+        mock_storage.read_persons.return_value = [person3, person1, person2]
 
-@patch("pylms.pylms.storage")
-@patch("pylms.pylms._interactive_person_details")
-@patch("pylms.pylms._interactive_select_person")
-def test_update_person_out_of_several(mock_select, mock_person_details, mock_storage):
-    person1 = Person(1, "foo", "bar")
-    person2 = Person(2, "foo", "bar")
-    person3 = Person(3, "foo", "bar")
-    mock_select.return_value = person2
-    mock_person_details.return_value = ("donut", "acme")
-    mock_storage.read_persons.return_value = [person3, person1, person2]
+        update_person("p")
 
-    update_person("p")
-
-    mock_select.assert_called_once_with("p")
-    assert mock_storage.read_persons.call_count == 1
-    assert mock_storage.store_persons.call_count == 1
-    mock_storage.store_persons.assert_called_once_with([person3, person1, Person(2, "donut", "acme")])
-
-
-@patch("builtins.print")
-@patch("pylms.pylms.storage")
-@patch("pylms.pylms._interactive_hit_enter")
-@patch("pylms.pylms._print_person")
-@patch("pylms.pylms._interactive_select_person")
-def test_delete_person(mock_select, mock_print_person, mock_hit_enter, mock_storage, mock_print):
-    person1 = Person(1, "foo", "bar")
-    person2 = Person(2, "foo", "bar")
-    person3 = Person(3, "foo", "bar")
-    mock_select.return_value = person3
-    mock_storage.read_persons.return_value = [person3, person2, person1]
-
-    delete_person("p")
-
-    mock_select.assert_called_once_with("p")
-    assert mock_select.call_count == 1
-    mock_print.assert_has_calls([call("Hit ENTER to delete:"), call("CTRL+C to exit")])
-    assert mock_print.call_count == 2
-    mock_print_person.assert_called_once_with(person3)
-    assert mock_print_person.call_count == 1
-    mock_hit_enter.assert_called_once_with()
-    assert mock_hit_enter.call_count == 1
-    mock_storage.read_persons.assert_called_once_with()
-    assert mock_storage.read_persons.call_count == 1
-    mock_storage.store_persons.assert_called_once_with([person2, person1])
-    assert mock_storage.store_persons.call_count == 1
+        mock_select.assert_called_once_with("p")
+        assert mock_storage.read_persons.call_count == 1
+        assert mock_storage.store_persons.call_count == 1
+        mock_storage.store_persons.assert_called_once_with([person3, person1, Person(2, "donut", "acme")])
 
 
-@patch("builtins.print")
-@patch("pylms.pylms.storage")
-@patch("pylms.pylms._interactive_hit_enter")
-@patch("pylms.pylms._print_person")
-@patch("pylms.pylms._interactive_select_person")
-def test_delete_person(mock_select, mock_print_person, mock_hit_enter, mock_storage, mock_print):
-    mock_select.return_value = None
+class Test_delete_person:
 
-    delete_person("p")
+    @patch("builtins.print")
+    @patch("pylms.pylms.storage")
+    @patch("pylms.pylms._interactive_hit_enter")
+    @patch("pylms.pylms._print_person")
+    @patch("pylms.pylms._interactive_select_person")
+    def test_delete_person(self, mock_select, mock_print_person, mock_hit_enter, mock_storage, mock_print):
+        person1 = Person(1, "foo", "bar")
+        person2 = Person(2, "foo", "bar")
+        person3 = Person(3, "foo", "bar")
+        mock_select.return_value = person3
+        mock_storage.read_persons.return_value = [person3, person2, person1]
 
-    mock_select.assert_called_once_with("p")
-    assert mock_select.call_count == 1
-    assert mock_print_person.call_count == 0
-    assert mock_hit_enter.call_count == 0
-    assert mock_storage.call_count == 0
-    assert mock_print.call_count == 0
+        delete_person("p")
+
+        mock_select.assert_called_once_with("p")
+        assert mock_select.call_count == 1
+        mock_print.assert_has_calls([call("Hit ENTER to delete:"), call("CTRL+C to exit")])
+        assert mock_print.call_count == 2
+        mock_print_person.assert_called_once_with(person3)
+        assert mock_print_person.call_count == 1
+        mock_hit_enter.assert_called_once_with()
+        assert mock_hit_enter.call_count == 1
+        mock_storage.read_persons.assert_called_once_with()
+        assert mock_storage.read_persons.call_count == 1
+        mock_storage.store_persons.assert_called_once_with([person2, person1])
+        assert mock_storage.store_persons.call_count == 1
+
+    @patch("builtins.print")
+    @patch("pylms.pylms.storage")
+    @patch("pylms.pylms._interactive_hit_enter")
+    @patch("pylms.pylms._print_person")
+    @patch("pylms.pylms._interactive_select_person")
+    def test_no_person_selected_to_delete(
+        self, mock_select, mock_print_person, mock_hit_enter, mock_storage, mock_print
+    ):
+        mock_select.return_value = None
+
+        delete_person("p")
+
+        mock_select.assert_called_once_with("p")
+        assert mock_select.call_count == 1
+        assert mock_print_person.call_count == 0
+        assert mock_hit_enter.call_count == 0
+        assert mock_storage.call_count == 0
+        assert mock_print.call_count == 0
+
+
+class Test_link_person:
+
+    def test_empty_request(self):
+        assert link_persons("") is None
+
+    @patch("pylms.pylms._parse_nl_link_request")
+    def test_no_relationship_definition_match(self, mock_parse_link_request):
+        mock_parse_link_request.return_value = None
+        request = "p"
+
+        assert link_persons(request) is None
+
+        mock_parse_link_request.assert_called_once_with(request)
+        assert mock_parse_link_request.call_count == 1

--- a/tests/pylms/storage_test.py
+++ b/tests/pylms/storage_test.py
@@ -1,20 +1,21 @@
 from datetime import datetime
 from pathlib import Path
-from pylms.core import Person
+from pylms.core import Person, Relationship, RelationshipDefinition
 from pylms.storage import read_persons, store_persons
-from pytest import raises
+from pylms.storage import read_relationships, store_relationships
+from pytest import raises, mark
 from unittest.mock import patch
 
 
 def test_read_persons_no_file(tmpdir):
-    with patch("pylms.storage.file_name", tmpdir + "foo.db"):
+    with patch("pylms.storage.persons_file_name", tmpdir + "foo.db"):
         assert not read_persons()
 
 
 def test_read_persons_empty_file(tmpdir):
     file_name = tmpdir + "foo.db"
     Path(file_name).touch()
-    with patch("pylms.storage.file_name", file_name):
+    with patch("pylms.storage.persons_file_name", file_name):
         assert not read_persons()
 
 
@@ -24,7 +25,7 @@ def test_read_one_person_with_lastname(tmpdir):
     with file.open("w"):
         file.write_text('[{"id": 11, "firstname": "John", "lastname": "Doe", "created": "2024-04-16 12:40:30.407998"}]')
 
-    with patch("pylms.storage.file_name", file_name):
+    with patch("pylms.storage.persons_file_name", file_name):
         persons = read_persons()
         assert len(persons) == 1
         assert persons[0].person_id == 11
@@ -39,7 +40,7 @@ def test_read_one_person_without_lastname(tmpdir):
     with file.open("w"):
         file.write_text(r'[{"id": 10, "firstname": "S\u00e9bastien", "created": "2024-04-16 12:40:30"}]')
 
-    with patch("pylms.storage.file_name", file_name):
+    with patch("pylms.storage.persons_file_name", file_name):
         persons = read_persons()
         assert len(persons) == 1
         assert persons[0].person_id == 10
@@ -48,7 +49,7 @@ def test_read_one_person_without_lastname(tmpdir):
         assert persons[0].created == datetime(2024, 4, 16, 12, 40, 30)
 
 
-def test_store_empty_list():
+def test_store_empty_list_of_persons():
     with raises(ValueError, match="Can't store an empty list of Persons."):
         store_persons([])
 
@@ -58,7 +59,7 @@ def test_store_one_person_with_lastname(tmpdir):
     file = Path(file_name)
     person = Person(1, "Jim", "Morisson", created=datetime(2024, 4, 5, 12, 41, 9))
 
-    with patch("pylms.storage.file_name", file_name):
+    with patch("pylms.storage.persons_file_name", file_name):
         store_persons([person])
 
     with file.open("r"):
@@ -73,7 +74,7 @@ def test_store_one_person_without_lastname(tmpdir):
     file = Path(file_name)
     person = Person(2, "Jim", created=datetime(2024, 4, 5, 12, 41, 58))
 
-    with patch("pylms.storage.file_name", file_name):
+    with patch("pylms.storage.persons_file_name", file_name):
         store_persons([person])
 
     with file.open("r"):
@@ -85,9 +86,13 @@ def test_store_persons(tmpdir):
     file = Path(file_name)
     t1 = datetime(2024, 4, 5, 12, 41, 58)
     t2 = datetime(2024, 9, 18, 21, 8, 8)
-    persons = [Person(3, "Sébastien", "Lesaint", t1), Person(4, "Max", "Payne", t2), Person(5, "Bob", created=t2)]
+    persons = [
+        Person(3, "Sébastien", "Lesaint", t1),
+        Person(4, "Max", "Payne", t2),
+        Person(5, "Bob", created=t2),
+    ]
 
-    with patch("pylms.storage.file_name", file_name):
+    with patch("pylms.storage.persons_file_name", file_name):
         store_persons(persons)
 
     with file.open("r"):
@@ -98,3 +103,184 @@ def test_store_persons(tmpdir):
             '{"id": 5, "firstname": "Bob", "created": "2024-09-18 21:08:08"}'
             "]"
         )
+
+
+def test_store_empty_list_of_relationships():
+    with raises(ValueError, match="Can't store an empty list of Relationships."):
+        store_relationships([])
+
+
+def test_store_one_relationship(tmpdir):
+    file_name = tmpdir + "foo.db"
+    file = Path(file_name)
+    person1 = Person(1, "Jim", "Morisson")
+    person2 = Person(2, "Paul", "John")
+    definition = RelationshipDefinition(name="rs_name")
+    relationship = Relationship(person_left=person1, person_right=person2, definition=definition)
+
+    with patch("pylms.storage.relationships_file_name", file_name):
+        store_relationships([relationship])
+
+    with file.open("r"):
+        assert file.read_text() == '[{"left": 1, "right": 2, "definition": "rs_name"}]'
+
+
+def test_store_relationships(tmpdir):
+    file_name = tmpdir + "foo.db"
+    file = Path(file_name)
+    person1 = Person(1, "Jim", "Morisson")
+    person2 = Person(2, "Paul", "John")
+    person3 = Person(3, "Tony", "Parker")
+    definition1 = RelationshipDefinition(name="rs1_name")
+    definition2 = RelationshipDefinition(name="rs2_name")
+
+    with patch("pylms.storage.relationships_file_name", file_name):
+        store_relationships(
+            [
+                Relationship(person_left=person1, person_right=person2, definition=definition1),
+                Relationship(person_left=person2, person_right=person3, definition=definition2),
+                Relationship(person_left=person3, person_right=person2, definition=definition1),
+                Relationship(person_left=person1, person_right=person3, definition=definition2),
+                Relationship(person_left=person1, person_right=person2, definition=definition1),
+            ]
+        )
+
+    with file.open("r"):
+        assert file.read_text() == (
+            "["
+            '{"left": 1, "right": 2, "definition": "rs1_name"}'
+            ", "
+            '{"left": 2, "right": 3, "definition": "rs2_name"}'
+            ", "
+            '{"left": 3, "right": 2, "definition": "rs1_name"}'
+            ", "
+            '{"left": 1, "right": 3, "definition": "rs2_name"}'
+            ", "
+            '{"left": 1, "right": 2, "definition": "rs1_name"}'
+            "]"
+        )
+
+
+def test_read_relationships_empty_list_of_persons():
+    with raises(ValueError, match="Persons can't be empty"):
+        read_relationships([])
+
+
+def test_read_relationships_no_file(tmpdir):
+    persons = [Person(2, "Foo", "Bar")]
+
+    with patch("pylms.storage.relationships_file_name", tmpdir + "foo.db"):
+        assert not read_relationships(persons)
+
+
+def test_read_relationships_empty_file(tmpdir):
+    persons = [Person(2, "Foo", "Bar")]
+    file_name = tmpdir + "foo.db"
+    Path(file_name).touch()
+
+    with patch("pylms.storage.relationships_file_name", file_name):
+        assert not read_relationships(persons)
+
+
+def test_read_one_relationship(tmpdir):
+    file_name = tmpdir + "foo.db"
+    persons = [
+        Person(2, "Foo", "Bar"),
+        Person(3, "Acme", "Donut"),
+    ]
+    relationship = RelationshipDefinition(name="rs1_name")
+    file = Path(file_name)
+    with file.open("w"):
+        file.write_text('[{"left": 3, "right": 2, "definition": "rs1_name"}]')
+
+    with (
+        patch("pylms.storage.relationships_file_name", file_name),
+        patch("pylms.storage.relationship_definitions", new=[relationship]),
+    ):
+        relationships = read_relationships(persons)
+        assert len(relationships) == 1
+        assert relationships[0].left == persons[1]
+        assert relationships[0].right == persons[0]
+        assert relationships[0].definition is relationship
+
+
+@mark.parametrize(
+    "serialized_relationship",
+    [
+        '{"left": 4, "right": 2, "definition": "rs1_name"}',
+        '{"left": 3, "right": 1, "definition": "rs1_name"}',
+        '{"left": 3, "right": 2, "definition": "does_not_exist"}',
+        '{"left": 4, "right": 2, "definition": "rs1_name"}',
+        '{"left": 1, "right": 4, "definition": "rs1_name"}',
+        '{"left": 10, "right": 12, "definition": "does_not_exist"}',
+    ],
+)
+def test_read_relationship_ignore_entry_if_person_or_definition_does_not_exist(serialized_relationship, tmpdir):
+    file_name = tmpdir + "foo.db"
+    persons = [
+        Person(2, "Foo", "Bar"),
+        Person(3, "Acme", "Donut"),
+    ]
+    relationship = RelationshipDefinition(name="rs1_name")
+    file = Path(file_name)
+    with file.open("w"):
+        file.write_text(f"[{serialized_relationship}]")
+
+    with (
+        patch("pylms.storage.relationships_file_name", file_name),
+        patch("pylms.storage.relationship_definitions", new=[relationship]),
+    ):
+        assert not read_relationships(persons)
+
+
+def test_read_relationships(tmpdir):
+    file_name = tmpdir + "foo.db"
+    persons = [
+        Person(1, "Jim", "Morisson"),
+        Person(2, "Paul", "John"),
+        Person(3, "Tony", "Parker"),
+    ]
+    relationship1 = RelationshipDefinition(name="rs1_name")
+    relationship2 = RelationshipDefinition(name="rs2_name")
+    file = Path(file_name)
+    with file.open("w"):
+        file.write_text(
+            "["
+            '{"left": 1, "right": 2, "definition": "rs1_name"}'
+            ", "
+            '{"left": 2, "right": 3, "definition": "rs2_name"}'
+            ", "
+            '{"left": 3, "right": 2, "definition": "rs1_name"}'
+            ", "
+            '{"left": 1, "right": 3, "definition": "rs2_name"}'
+            ", "
+            '{"left": 1, "right": 2, "definition": "rs1_name"}'
+            "]"
+        )
+
+    with (
+        patch("pylms.storage.relationships_file_name", file_name),
+        patch("pylms.storage.relationship_definitions", new=[relationship1, relationship2]),
+    ):
+        relationships = read_relationships(persons)
+        assert len(relationships) == 5
+
+        assert relationships[0].left == persons[0]
+        assert relationships[0].right == persons[1]
+        assert relationships[0].definition is relationship1
+
+        assert relationships[1].left == persons[1]
+        assert relationships[1].right == persons[2]
+        assert relationships[1].definition is relationship2
+
+        assert relationships[2].left == persons[2]
+        assert relationships[2].right == persons[1]
+        assert relationships[2].definition is relationship1
+
+        assert relationships[3].left == persons[0]
+        assert relationships[3].right == persons[2]
+        assert relationships[3].definition is relationship2
+
+        assert relationships[4].left == persons[0]
+        assert relationships[4].right == persons[1]
+        assert relationships[4].definition is relationship1


### PR DESCRIPTION
# WHY

When I don't remember a person's first name and/or last name, most of the time I can recall how he/she relates to some other person.

To leverage relationships for search, we must first record them.

Let's record the core family relationships as a first step.

# WHAT

Family relationship are bi-directional:

* "père de" one way, "fils de" or "fille de" the other way
* "mère de" one way, "fils de" or "fille de" the other way
* "soeur de" one way, "soeur de" or "frère de" the other way

As a consequence: 

* relationships between persons can be created one way or the other
* it should create the relationship the other way around

Also, "père" vs "mère" or "fils" vs "fille" depends on the sex of the person.

Since we don't know this information yet, we can only record the relationship "parent/enfant" and, for now, support all of the above relationship names are "alias" to this single one.

HOW

`pylms link Seb père de Antonin` will:

* identify the relationship name père de in the string Seb père de Antonin
    * if no relationship name or alias could be found in the string, display 
    `No relationship found`
    * followed by the list of supported relationship names:
        * `père de`
        * `fils de`
        * `fille de`
        * `mère de`
* search for a person matching Seb and a person matching Antonin (case insensitive, same as for update or delete)
    * if no match for one or both persons, display, one person per line, in order of input:
        * if found `(2) John Doe (2024-4-16 13-11-44)`
        * if not found `No match for "Seb"`
    * if multiple matches for one or both persons, display, in order of input of the persons:
    ```
    Input id of Person to link for "John":
    (2) John Doe (2024-4-16 13-11-44)
    (6) John Deer (2024-5-16 13-11-44) 
    CTRL+C to exit
    ```
    * Once both persons are selected, display
    ```
    Hit ENTER to link as "parent/enfant":
    (2) John Doe (2024-4-16 13-11-44)
    (6) John Deer (2024-5-16 13-11-44) 
    CTRL+C to exit
    ```

`pylms` now displays relationships:

* Under each member of the relationship, displays the name of the relationship and the id, first name and last name of the other member   
```
(2) John Doe (2024-4-16 13-11-44)
    -> Parent/Enfant de (4) Peter
(3) TIna Doe (2024-4-16 15-12-30)
    -> Parent/Enfant de (4) Peter
(4) Peter (2024-4-17 11-47-57)
    -> Parent/Enfant de (2) John Doe
    -> Parent/Enfant de (3) Tina Doe
```