### PR TITLE
PYL-25 display a relationship name for left or right person

### DIFF
--- a/src/pylms/core.py
+++ b/src/pylms/core.py
@@ -49,8 +49,16 @@ class PersonIdGenerator:
 
 
 class RelationshipDefinition:
-    def __init__(self, name: str, aliases: list[str] = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        aliases: list[str] = None,
+        person_left_repr: str = None,
+        person_right_repr: str = None,
+    ) -> None:
         self._name: str = name
+        self._person_left_repr: str = name if person_left_repr is None else person_left_repr
+        self._person_right_repr: str = name if person_right_repr is None else person_right_repr
         self._aliases: list[str] = [] if aliases is None else aliases[:]
 
     @property
@@ -60,6 +68,12 @@ class RelationshipDefinition:
     @property
     def aliases(self) -> list[str]:
         return self._aliases
+
+    def left_repr(self, person: Person) -> str:
+        return self._person_left_repr
+
+    def right_repr(self, person: Person) -> str:
+        return self._person_right_repr
 
     def __repr__(self) -> str:
         return self._name
@@ -75,6 +89,8 @@ parent_enfant = RelationshipDefinition(
         "parent de",
         "enfant de",
     ],
+    person_left_repr="parent",
+    person_right_repr="enfant",
 )
 
 relationship_definitions = [
@@ -96,12 +112,19 @@ class Relationship:
     def right(self) -> Person:
         return self._person_right
 
+    @property
+    def definition(self) -> RelationshipDefinition:
+        return self._definition
+
     def applies_to(self, person: Person) -> bool:
         return self._person_left == person or self._person_right == person
 
-    @property
-    def definition(self):
-        return self._definition
+    def repr_for(self, person: Person) -> str:
+        if person == self._person_left:
+            return self._definition.left_repr(person)
+        if person == self._person_right:
+            return self._definition.right_repr(person)
+        raise ValueError(f"{person} is neither the left nor right person of this {self._definition.name} relationship")
 
 
 def resolve_persons(persons: list[Person], relationships: list[Relationship]) -> list[(Person, list[Relationship])]:

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -25,7 +25,7 @@ def list_persons() -> None:
             _print_person(person)
             for r in rs:
                 other = r.right if r.left == person else r.left
-                print(f"    -> {r.definition.name} de ({other.person_id}) {other}")
+                print(f"    -> {r.repr_for(person)} de ({other.person_id}) {other}")
     else:
         print("No Person registered yet.")
 

--- a/tests/pylms/core_test.py
+++ b/tests/pylms/core_test.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from pylms.pylms import Person
 from pylms.pylms import PersonIdGenerator
 from unittest.mock import patch
+from pylms.core import RelationshipDefinition, Relationship
+from pytest import raises
 
 
 @patch("pylms.core.datetime.datetime")
@@ -55,3 +57,26 @@ def test_generator_one_person():
     under_test = PersonIdGenerator([Person(2, "n")])
 
     assert under_test.next_person_id() == 3
+
+
+class TestRelationship:
+    person1 = Person(1, "John", "Doe")
+    person2 = Person(2, "Jane", "Doe")
+    person3 = Person(3, "Diana", "King")
+    definition = RelationshipDefinition(
+        name="FooDef",
+        person_left_repr="LeftFoo",
+        person_right_repr="RightFoo",
+    )
+    relationship = Relationship(person_left=person1, person_right=person2, definition=definition)
+
+    def test_repr_for_fails_if_neither_left_nor_right(self):
+        expected_message = f"{self.person3} is neither the left nor right person of this FooDef relationship"
+        with raises(ValueError, match=expected_message):
+            self.relationship.repr_for(self.person3)
+
+    def test_repr_for_left_person(self):
+        assert self.relationship.repr_for(self.person1) == "LeftFoo"
+
+    def test_repr_for_right_person(self):
+        assert self.relationship.repr_for(self.person2) == "RightFoo"

--- a/tests/pylms/pylms_protected_test.py
+++ b/tests/pylms/pylms_protected_test.py
@@ -128,8 +128,10 @@ class Test_interactive_hit_enter:
         assert mock_input.call_count == 4
 
 
-relationship_definition_1 = RelationshipDefinition(name="foo", aliases=["aaa", "bbb", "ccc"])
-relationship_definition_2 = RelationshipDefinition(name="bar", aliases=["11", "22", "33"])
+relationship_definition_1 = RelationshipDefinition(
+    name="foo", aliases=["aaa", "bbb", "ccc"], person_left_repr="leftFoo", person_right_repr="rightFoo"
+)
+relationship_definition_2 = RelationshipDefinition(name="bar", aliases=["11", "22", "33"], person_left_repr="leftBar")
 relationship_definition_3 = RelationshipDefinition(name="acme", aliases=["a2", "b3", "c4"])
 
 


### PR DESCRIPTION
# WHY

Currently, both relationships are displayed the same under each member of the relationship.

This can be improved.

# WHAT

Display `-> enfant de John Doe` and `-> parent de Tina Doe` appropriately under John Doe and Tina Doe

# HOW

If  the `Person` object is the left `Person` of the `Relationship`, display `-> parent de Tina Doe`

If the  `Person` object is the right `Person` of the `Relationship`, display `-> enfant de John Doe`