### PR TITLE
PYL-27 add relationship copain/copine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist
 .coverage
 __pycache__
 
+# PyCharm
+.idea
+
 # PyLMS
 persons.db
 relationships.db

--- a/src/pylms/core.py
+++ b/src/pylms/core.py
@@ -93,9 +93,14 @@ parent_enfant = RelationshipDefinition(
     person_right_repr="enfant",
 )
 
-relationship_definitions = [
-    parent_enfant,
-]
+copain_copine = RelationshipDefinition(
+    name="Copain/Copine",
+    aliases=["copain de", "copine de"],
+    person_left_repr="copain",
+    person_right_repr="copain",
+)
+
+relationship_definitions = [parent_enfant, copain_copine]
 
 
 class Relationship:


### PR DESCRIPTION
# WHY

To expand our thinking and design, we need a second instance of a relationship, and it must be non directional.

# WHAT

copain/copine matches the requirement.

# HOW

* name: copain/copine
* aliases: "copain de" et "copine de"