### PR TITLE
PYL28 Set sex of Person during link creation + PYL-29 relationship display is wrong when using fils de or fille de

### DIFF
--- a/src/pylms/cli.py
+++ b/src/pylms/cli.py
@@ -1,3 +1,4 @@
+from pylms.core import RelationshipAlias
 from pylms.pylms import IOs, EventListener, ExitPyLMS
 from pylms.pylms import Person, Relationship, RelationshipDefinition
 
@@ -109,3 +110,6 @@ class CLI(IOs, EventListener):
         self.show_person(person_right)
         print("CTRL+C to exit")
         self._interactive_hit_enter()
+
+    def configured_from_alias(self, person: Person, alias: RelationshipAlias) -> None:
+        print(f"Sex of {person} set to {person.sex} from alias {alias.name}")

--- a/src/pylms/cli.py
+++ b/src/pylms/cli.py
@@ -11,6 +11,7 @@ class CLI(IOs, EventListener):
         created = person.created
         print(
             f"({person.person_id})",
+            f" {person.sex.name}" if person.sex is not None else "",
             person,
             f"({created.year}-{created.month}-{created.day} {created.hour}-{created.minute}-{created.second})",
         )

--- a/src/pylms/core.py
+++ b/src/pylms/core.py
@@ -83,25 +83,48 @@ class PersonIdGenerator:
         return res
 
 
+class RelationshipAlias:
+    def __init__(self, name: str, *, left_person_sex: Sex = None, right_person_sex: Sex = None) -> None:
+        self._name: str = name
+        self._left_person_sex: Sex = left_person_sex
+        self._right_person_sex: Sex = right_person_sex
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def configure_left_person(self, person: Person) -> Person | None:
+        if person.sex is None and self._left_person_sex is not None:
+            person.sex = self._left_person_sex
+            return person
+        return None
+
+    def configure_right_person(self, person: Person) -> Person | None:
+        if person.sex is None and self._right_person_sex is not None:
+            person.sex = self._right_person_sex
+            return person
+        return None
+
+
 class RelationshipDefinition:
     def __init__(
         self,
         name: str,
-        aliases: list[str] = None,
+        aliases: list[RelationshipAlias] = None,
         person_left_repr: str = None,
         person_right_repr: str = None,
     ) -> None:
         self._name: str = name
         self._person_left_repr: str = name if person_left_repr is None else person_left_repr
         self._person_right_repr: str = name if person_right_repr is None else person_right_repr
-        self._aliases: list[str] = [] if aliases is None else aliases[:]
+        self._aliases: list[RelationshipAlias] = [] if aliases is None else aliases[:]
 
     @property
     def name(self) -> str:
         return self._name
 
     @property
-    def aliases(self) -> list[str]:
+    def aliases(self) -> list[RelationshipAlias]:
         return self._aliases
 
     def left_repr(self, person: Person) -> str:
@@ -117,12 +140,12 @@ class RelationshipDefinition:
 parent_enfant = RelationshipDefinition(
     name="Parent/Enfant",
     aliases=[
-        "père de",
-        "mère de",
-        "fils de",
-        "fille de",
-        "parent de",
-        "enfant de",
+        RelationshipAlias("père de", left_person_sex=MALE),
+        RelationshipAlias("mère de", left_person_sex=FEMALE),
+        RelationshipAlias("fils de", right_person_sex=MALE),
+        RelationshipAlias("fille de", right_person_sex=FEMALE),
+        RelationshipAlias("parent de"),
+        RelationshipAlias("enfant de"),
     ],
     person_left_repr="parent",
     person_right_repr="enfant",
@@ -130,12 +153,15 @@ parent_enfant = RelationshipDefinition(
 
 copain_copine = RelationshipDefinition(
     name="Copain/Copine",
-    aliases=["copain de", "copine de"],
+    aliases=[
+        RelationshipAlias("copain de", right_person_sex=MALE),
+        RelationshipAlias("copine de", right_person_sex=FEMALE),
+    ],
     person_left_repr="copain",
     person_right_repr="copain",
 )
 
-relationship_definitions = [parent_enfant, copain_copine]
+relationship_definitions: list[RelationshipDefinition] = [parent_enfant, copain_copine]
 
 
 class Relationship:

--- a/src/pylms/core.py
+++ b/src/pylms/core.py
@@ -1,8 +1,28 @@
 import datetime
 
 
+class Sex:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+
+MALE: Sex = Sex("MALE")
+FEMALE: Sex = Sex("FEMALE")
+
+
 class Person:
-    def __init__(self, person_id: int, firstname: str, lastname: str = None, created: datetime.datetime = None) -> None:
+    def __init__(
+        self,
+        person_id: int,
+        firstname: str,
+        lastname: str = None,
+        created: datetime.datetime = None,
+        sex: Sex = None,
+    ) -> None:
         if person_id is None:
             raise ValueError("id can't be None")
         if not firstname:
@@ -11,10 +31,17 @@ class Person:
         self.person_id = int(person_id)
         self.firstname = firstname
         self.lastname = lastname
-        self.created = Person.check_or_set(created)
+        self._sex = None if sex is None else Person._check_sex(sex)
+        self.created = Person._check_or_set_created(created)
 
     @staticmethod
-    def check_or_set(dt: datetime.datetime | None) -> datetime.datetime:
+    def _check_sex(sex: Sex) -> Sex:
+        if sex != MALE and sex != FEMALE:
+            raise ValueError("Sex must be either constant MALE or FEMALE")
+        return sex
+
+    @staticmethod
+    def _check_or_set_created(dt: datetime.datetime | None) -> datetime.datetime:
         if not dt:
             return datetime.datetime.now()
         # can't make isinstance work:  :'(
@@ -22,6 +49,14 @@ class Person:
         # if not isinstance(dt, datetime.datetime):
         #     raise ValueError(f"created parameter must be a datetime (got {type(dt)})")
         return dt
+
+    @property
+    def sex(self) -> Sex | None:
+        return self._sex
+
+    @sex.setter
+    def sex(self, sex: Sex) -> None:
+        self._sex = Person._check_sex(sex)
 
     def __eq__(self, other: any) -> bool:
         if isinstance(other, Person):

--- a/src/pylms/core.py
+++ b/src/pylms/core.py
@@ -9,6 +9,9 @@ class Sex:
     def name(self):
         return self._name
 
+    def __repr__(self):
+        return self.name
+
 
 MALE: Sex = Sex("MALE")
 FEMALE: Sex = Sex("FEMALE")

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -81,12 +81,7 @@ def update_person(pattern: str) -> None:
 
     updated_person = ios.update_person(person_to_update)
 
-    persons = storage.read_persons()
-    for person in persons:
-        if person.person_id == person_to_update.person_id:
-            person.firstname = updated_person.firstname
-            person.lastname = updated_person.lastname
-    storage.store_persons(persons)
+    storage.update_person(updated_person)
 
 
 def search_person(pattern: str) -> None:
@@ -198,6 +193,7 @@ def _configure_person(alias: RelationshipAlias, person: Person, configure_method
     if configured_person is None:
         return person
     events.configured_from_alias(alias=alias, person=configured_person)
+    storage.update_person(person)
     return configured_person
 
 

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -206,27 +206,31 @@ def link_persons(natural_language_link_request: str) -> None:
     if link_request is None:
         return
 
-    person_left = _select_person(link_request.left_person_pattern)
-    person_right = _select_person(link_request.right_person_pattern)
+    rq_person_left = _select_person(link_request.left_person_pattern)
+    rq_person_right = _select_person(link_request.right_person_pattern)
 
-    if person_left is None:
+    if rq_person_left is None:
         logger.info(f'No match for "{link_request.left_person_pattern}".')
-    if person_right is None:
+    if rq_person_right is None:
         logger.info(f'No match for "{link_request.right_person_pattern}".')
-    if person_left is None or person_right is None:
+    if rq_person_left is None or rq_person_right is None:
         return
 
     # configure persons from alias, if any
-    configured_person_left = _configure_person(link_request.alias, person_left, "configure_left_person")
-    configured_person_right = _configure_person(link_request.alias, person_right, "configure_right_person")
+    person_left = _configure_person(link_request.alias, rq_person_left, "configure_left_person")
+    person_right = _configure_person(link_request.alias, rq_person_right, "configure_right_person")
+
+    rl_person_left, rl_person_right = link_request.alias.to_relationship_definition_direction(
+        left_person=person_left, right_person=person_right
+    )
 
     # create link
-    events.creating_link(link_request.definition, configured_person_left, configured_person_right)
+    events.creating_link(link_request.definition, rl_person_left, rl_person_right)
     persons = storage.read_persons()
     relationships = storage.read_relationships(persons)
     relationship = Relationship(
-        person_left=configured_person_left,
-        person_right=configured_person_right,
+        person_left=rl_person_left,
+        person_right=rl_person_right,
         definition=link_request.definition,
     )
     storage.store_relationships(relationships + [relationship])

--- a/src/pylms/storage.py
+++ b/src/pylms/storage.py
@@ -1,34 +1,71 @@
 from datetime import datetime
 import json
 from pathlib import Path
-from pylms.core import Person, Relationship, relationship_definitions
+from pylms.core import Person, Relationship, relationship_definitions, Sex, MALE, FEMALE
 
 persons_file_name = "persons.db"
 relationships_file_name = "relationships.db"
+
+
+def _from_sex(sex: Sex | None) -> str | None:
+    if sex is None:
+        return None
+    if sex == MALE:
+        return "M"
+    if sex == FEMALE:
+        return "F"
+    raise ValueError(f"Unsupported sex {sex}")
 
 
 class PersonEncoder(json.JSONEncoder):
     def default(self, o: any) -> any:
         if isinstance(o, Person):
             if o.lastname:
-                return {"id": o.person_id, "firstname": o.firstname, "lastname": o.lastname, "created": str(o.created)}
-            return {"id": o.person_id, "firstname": o.firstname, "created": str(o.created)}
+                return {
+                    "id": o.person_id,
+                    "firstname": o.firstname,
+                    "lastname": o.lastname,
+                    "created": str(o.created),
+                    "sex": _from_sex(o.sex),
+                }
+            return {
+                "id": o.person_id,
+                "firstname": o.firstname,
+                "created": str(o.created),
+                "sex": _from_sex(o.sex),
+            }
         # Let the base class default method raise the TypeError
         return super().default(o)
+
+
+def _to_sex(o: dict) -> Sex | None:
+    try:
+        sex = o["sex"]
+        if sex is None:
+            return None
+        if sex == "M":
+            return MALE
+        if sex == "F":
+            return FEMALE
+        raise ValueError(f"Unsupported value {sex} for sex")
+    except KeyError:
+        return None
 
 
 def to_person(o: dict) -> Person:
     if "firstname" not in o:
         raise ValueError(f"Missing field 'firstname' type(o=={type(o)} o={str(o)}")
 
+    sex: Sex = _to_sex(o)
     if "lastname" in o:
         return Person(
             person_id=o["id"],
             firstname=o["firstname"],
             lastname=o["lastname"],
             created=datetime.fromisoformat(o["created"]),
+            sex=sex,
         )
-    return Person(person_id=o["id"], firstname=o["firstname"], created=datetime.fromisoformat(o["created"]))
+    return Person(person_id=o["id"], firstname=o["firstname"], created=datetime.fromisoformat(o["created"]), sex=sex)
 
 
 def store_persons(persons: list[Person]) -> None:
@@ -105,3 +142,14 @@ def read_relationships(persons: list[Person]) -> list[Relationship]:
                 return list(filter(lambda t: t is not None, res))
 
     return []
+
+
+def update_person(person_to_update: Person) -> None:
+    persons = read_persons()
+    for p in persons[:]:
+        if p.person_id == person_to_update.person_id:
+            persons.remove(p)
+            persons.append(person_to_update)
+            store_persons(persons)
+            return
+    raise ValueError(f"Can't find person with id {person_to_update.person_id}")

--- a/tests/pylms/core_test.py
+++ b/tests/pylms/core_test.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from pylms.pylms import Person
 from pylms.pylms import PersonIdGenerator
 from unittest.mock import patch
-from pylms.core import RelationshipDefinition, Relationship
-from pytest import raises
+from pylms.core import RelationshipDefinition, Relationship, Sex, MALE, FEMALE
+from pytest import raises, mark
 
 
 @patch("pylms.core.datetime.datetime")
@@ -80,3 +80,26 @@ class TestRelationship:
 
     def test_repr_for_right_person(self):
         assert self.relationship.repr_for(self.person2) == "RightFoo"
+
+
+class TestPersonSex:
+    @mark.parametrize("constant_sex", [MALE, FEMALE])
+    def test_init_accepts_constant_as_parameter(self, constant_sex):
+        Person(person_id=1, firstname="foo", lastname="acme", sex=constant_sex)
+
+    @mark.parametrize("non_constant_sex", [Sex("MALE"), Sex("FEMALE"), Sex("FOO")])
+    def test_init_fails_if_sex_is_not_constant(self, non_constant_sex):
+        with raises(ValueError, match="Sex must be either constant MALE or FEMALE"):
+            Person(person_id=1, firstname="foo", lastname="bar", sex=non_constant_sex)
+
+    @mark.parametrize(
+        "person",
+        [
+            Person(person_id=1, firstname="foo", sex=None),
+            Person(person_id=1, firstname="foo", sex=MALE),
+        ],
+    )
+    @mark.parametrize("non_constant_sex", [Sex("MALE"), Sex("FEMALE"), Sex("FOO")])
+    def test_setter_fails_if_sex_is_not_constant(self, person, non_constant_sex):
+        with raises(ValueError, match="Sex must be either constant MALE or FEMALE"):
+            Person(person_id=1, firstname="foo", lastname="bar", sex=non_constant_sex)

--- a/tests/pylms/pymls_test.py
+++ b/tests/pylms/pymls_test.py
@@ -153,39 +153,37 @@ class Test_update_person:
         update_person("p")
 
         mock_select.assert_called_once_with("p")
-        assert mock_storage.store_persons.call_count == 0
+        assert mock_storage.call_count == 0
 
     @patch("pylms.pylms.storage")
     @patch("pylms.pylms.ios.update_person")
     @patch("pylms.pylms._select_person")
     def test_single_person(self, mock_select, mock_update_person, mock_storage):
         person = Person(1, "foo", "bar")
+        updated_person = Person(234, "donut", "acme")
         mock_select.return_value = person
-        mock_update_person.return_value = Person(234, "donut", "acme")
-        mock_storage.read_persons.return_value = [person]
+        mock_update_person.return_value = updated_person
 
         update_person("p")
 
         mock_select.assert_called_once_with("p")
         mock_update_person.assert_called_once_with(person)
-        mock_storage.store_persons.assert_called_once_with([Person(1, "donut", "acme")])
+        mock_storage.update_person.assert_called_once_with(updated_person)
 
     @patch("pylms.pylms.storage")
     @patch("pylms.pylms.ios.update_person")
     @patch("pylms.pylms._select_person")
     def test_out_of_several(self, mock_select, mock_update_person, mock_storage):
-        person1 = Person(1, "foo", "bar")
         person2 = Person(2, "foo", "bar")
-        person3 = Person(3, "foo", "bar")
+        updated_person = Person(888, "donut", "acme")
         mock_select.return_value = person2
-        mock_update_person.return_value = Person(888, "donut", "acme")
-        mock_storage.read_persons.return_value = [person3, person1, person2]
+        mock_update_person.return_value = updated_person
 
         update_person("p")
 
         mock_select.assert_called_once_with("p")
         mock_update_person.assert_called_once_with(person2)
-        mock_storage.store_persons.assert_called_once_with([person3, person1, Person(2, "donut", "acme")])
+        mock_storage.update_person.assert_called_once_with(updated_person)
 
 
 class Test_delete_person:


### PR DESCRIPTION
# PYL28 Set sex of Person during link creation
## WHY

The sex of a person can be deduced from the relationship alias used in the link request:

* `Foo fils de Bar` implies that `Foo` is male
* `Bar mère de Foo` implies that `Bar` is female

## WHAT

* Introduce a `RelationshipAlias` class to replace the string currently representing an alias
* existing string is the name of the alias
* add methods to set the sex of left or right person
* call these method when creating a link

# PYL-29 relationship display is wrong when using fils de or fille de
## WHY

Command pylms link Peter fils de Dana wrongly displays:

(14) Delphine (2024-4-29 17-37-37)

    -> enfant de (18) Mattéo

(18) Mattéo (2024-4-29 22-3-22)

    -> parent de (14) Delphine

## WHAT

* `parent/enfant` is a directional relationship and the definition is using a default direction (parent=`left person`, enfant=`right person`)
* aliases such as `fils de` and `fille de` have persons in the opposite direction
* the `RelationshipAliasclass` has a method that will, depending on whether the alias uses the opposite direction of the definition, return the appropriate left and right person for the relationship
* this method is called when creating a link