### PR TITLE
PYL-32 Add usage documentation to README.md and move project's rational to dedicated file

### DIFF
--- a/PROJECT_RATIONAL.md
+++ b/PROJECT_RATIONAL.md
@@ -1,0 +1,143 @@
+Purpose of the project
+======================
+
+The functional scope of this project is only a pretext for exploring, learning and practicing.
+
+It is also a support for demonstrating my autonomous work to learn new technologies and process, revolving around `Python`.
+
+Why `Python`?
+-------------
+
+I'm a `Java` developer since out of school (15 years at least).
+
+I've been using `Python` since 2022 for AWS CDK-based projects, writing data analysis notebooks with `panda`, `numpi`, `seaborn`, etc. and some scripting programs to run my backup strategy accross NAS and family member computers at home.
+
+I learned `Python` ad hoc.
+
+However, discussions with colleagues made me realize that I was "only" coding `Java` (or `bash` for scripting) with the `Python` language.
+
+This isn't good.
+
+In my whole life, I am commited to do things the right way. I have to learn and use `Python` the right way.
+
+Plus (with no order of importance):
+
+* I liked the language so far for itself and because it challenged me in my Java-way of looking at coding
+* I'm currently on the job market and `Python` is the trending programming language
+* `Python` is frequently used (along with `Go`) for projects I'm interrested into (cloud-based ones, data-based ones, AI-based ones), more than `Java`
+
+Why this project?
+-----------------
+
+So, I took leaving my job in February 2024 as an opportunity to learn `Python` from the ground up, autonomously, reading and practicing [Dead Simple Python](https://nostarch.com/dead-simple-python) from start to end.
+
+I then took practice exams [purchased on Udemy](https://www.udemy.com/course/certified-associate-professional-python-pcap-pcpp1/) for the [PCAP](https://pythoninstitute.org/pcap) [PCPP1](https://pythoninstitute.org/pcpp1) certifications, with the initial intent to pass them.
+
+I succeeded at both of them, 1st try.
+
+The ease of the certification made me doubt they would be enough to validate, prove and demonstrate my learning.
+
+A practical project will achieve this better.
+
+Why English?
+------------
+
+I've been coding, writing and communicating in English for 10 years, both at work and for personal code and documentation.
+
+I continue to target English-based jobs.
+
+Scope of the project
+====================
+
+Python and Python ecosystem
+---------------------------
+
+1. Python language and standard lib
+2. Python desktop UI frameworks (`tkinter` and then migrating to `PySide6`)
+	* `tkinter` because it's part of certification requirements
+	* `PySide6` because I think QT is more advanced and I could use it for personal project and this package because it's the most up to date
+3. Python testing frameworks (standard `unittest`, migrating `Ward` and GUI testing framework)
+	* interrested in `Ward` as a different approach to testing syntax
+	* curious of how to handle migration
+4. Python web framework (`Flask`) exploration and practice
+	* popular
+	* I like it's advertised as lightweigth
+5. Pythonic and clean programming
+6. Documentation with [Sphinx](https://www.sphinx-doc.org/en/master/)
+	* THE doc tool for Python
+	* I want to experiment with [reStructuredText](https://docutils.sourceforge.io/rst.html)
+7. Pythonic SQL with [sqlite3](https://docs.python.org/3/library/sqlite3.html)
+	* curious of the pythonic way for SQL
+	* every backend app does SQL
+
+New technology exploration
+--------------------------
+
+1. Experiment with Graph database usage (`GraphDB`?, `Neo4J`?)
+	* I'm proficient with relational, practitioner with document, never used graph
+2. Project management with a tool I don't know: [linear](https://linear.app)
+	* get out of confort-zone
+3. CI/CD with [Dagger](https://dagger.io/) on Circle-CI: https://docs.dagger.io/integrations/592501/circleci
+	* [KISS](https://fr.wikipedia.org/wiki/Principe_KISS) starting with Github actions
+	* Circle-CI seem to be quite popular and I've seen it on Job posting
+	* Dagger's concept is pretty could (and Python-based)
+
+Architecting demonstration
+--------------------------
+
+Evolves the program from a command line Proof-of-concept, to a GUI-based desktop app, to a server-based monolith program app, to a browser-based program, to a scaling SAAS service with microservices:
+
+1. explore and practice the whole variety of `Python` based programs
+2. demonstrate and practice architecting skills at all stages and handling migrations
+
+
+
+Work and time management
+========================
+
+Pomodoro
+--------
+
+Apply the [Pomodoro Technique](https://en.wikipedia.org/wiki/Pomodoro_Technique) for time management.
+
+I'll be using [Pomatez](https://github.com/zidoro/pomatez) as a Pomodoro tool.
+
+I'll work in rounds of 25 minutes, sets of 4 rounds in a row, 5 minutes breaks in between.
+
+This implies a realistic 2 sets a day target.
+
+Sprint simulation
+-----------------
+
+I intent to simulate a day with one 25 minutes round and weekly sprints with a set of 4 rounds:
+
+* ensure the project is fast-paced, quickly beneficial and doesn't last forever
+* push the timebox approach and the feeling of urgency I practiced for 9 years to a limit and see what happens
+
+
+Health, work and work-balance benefits
+--------------------------------------
+
+Additional reasons to use the Pomodoro technique:
+
+* Force me to take breaks:
+	* ease on my eyes getting impacted by all these years looking at a computer screen
+	* fight the impacts of the sitting position
+* Focus on work and use breaks for the small home related stuff
+* Become an advanced practitioner of the technique so that I'm really able to use it at work once I get back on a job (previous attempts in the past weren't successful)
+
+Project management
+==================
+
+Tooling
+-------
+
+This project is an opportunity to experiment with a new tool: [linear](https://linear.app).
+
+It appears to have (to confirm with practice):
+
+* a full keyboard user interface
+* concepts different from Jira for project management (circle?)
+* integration with Github for issue workflow
+* a roadmap feature to draw and track the project's steps and milestones
+* free usage

--- a/README.md
+++ b/README.md
@@ -1,152 +1,92 @@
-Lacune Mémorielle Sociale for Python
-====================================
+Lacune Mémorielle Sociale (LMS) for Python
+==========================================
 
-I have a long living issue to remember people names, history and relationships.
-Let's see how computer software could help improve (or fix, why not!) this situation.
+`PyLMS` a command line tool to create and manage Persons and their Relationships.
 
+WHY PyLMS
+=========
 
-Purpose of the project
-======================
+It starts from a real problem
+-----------------------------
 
-The functional scope of this project is only a pretext for exploring, learning and practicing.
+This is the best reason and use case for a software, right? :-) 
 
-It is also a support for demonstrating my autonomous work to learn new technologies and process, revolving around `Python`.
+My problem is that I have a long living issue to remember people names, history and relationships.
 
-Why `Python`?
--------------
+Certainly that could be improved (or fix!) with software, right?
 
-I'm a `Java` developer since out of school (15 years at least).
+Personal demo project for Python and other technologies
+-------------------------------------------------------
 
-I've been using `Python` since 2022 for AWS CDK-based projects, writing data analysis notebooks with `panda`, `numpi`, `seaborn`, etc. and some scripting programs to run my backup strategy accross NAS and family member computers at home.
+I needed a topic for a personal project that would give me an opportunity to learn and/or improve (and demo) on:
+* my practice of Python as a programming language and the Pythonic way (as a 20+ years Java developer)
+* a bunch of technologies, frameworks, etc.
+  * Graph databases, [`Flask`](https://flask.palletsprojects.com/en/3.0.x/), [`FastAPI`](https://fastapi.tiangolo.com/), ...
+  * Machine Learning for Natural Language processing
+  * ...
+* a fun application life cycle
+  * from a CLI POC
+  * to a GUI application
+  * to on-premises monolithic server
+  * to a cloud-based micro-services-based online service
+* coding practices:
+   * project management with [tickets](https://linear.app/pylms/) and [pull requests](https://github.com/lesaint/PyLMS/pulls?q=is%3Apr+is%3Aclosed)
+   * [hexagonal architecture](https://en.wikipedia.org/wiki/Hexagonal_architecture_(software))
+   * contract testing
+   * ...
 
-I learned `Python` ad hoc.
+Much more on the purpose and goals of this project and how I intend to run it [is available here](PROJECT_RATIONAL.md).
 
-However, discussions with colleagues made me realize that I was "only" coding `Java` (or `bash` for scripting) with the `Python` language.
+Install
+=======
 
-This isn't good.
+see [build](#how-to-build), [run and develop](#how-to-run-and-develop)
 
-In my whole life, I am commited to do things the right way. I have to learn and use `Python` the right way.
+Usage
+=====
 
-Plus (with no order of importance):
+* to list all Persons and Relationships: `pylms`
+* create a Person `pylms John Doe` or `pylms John`
+   * supports first name (single word) alone or first name and last name separated by a blank space 
+* to create a relationship `pylms link John Doe père de Tony Doe` or `pylms link John père de Tony`
+   * "père de" is an example of a Relationship alias and is looked up to tell apart the Persons in the linking request 
+   * list of supported relationship alias defined [here](/src/pylms/core.py#L195)
+* to delete a person `pylms delete John` or `pylms John`
+* to update the firstname/lastname of a person `pylms update John`
 
-* I liked the language so far for itself and because it challenged me in my Java-way of looking at coding
-* I'm currently on the job market and `Python` is the trending programming language
-* `Python` is frequently used (along with `Go`) for projects I'm interrested into (cloud-based ones, data-based ones, AI-based ones), more than `Java`
+Development
+===========
 
-Why this project?
------------------
-
-So, I took leaving my job in February 2024 as an opportunity to learn `Python` from the ground up, autonomously, reading and practicing [Dead Simple Python](https://nostarch.com/dead-simple-python) from start to end.
-
-I then took practice exams [purchased on Udemy](https://www.udemy.com/course/certified-associate-professional-python-pcap-pcpp1/) for the [PCAP](https://pythoninstitute.org/pcap) [PCPP1](https://pythoninstitute.org/pcpp1) certifications, with the initial intent to pass them.
-
-I succeeded at both of them, 1st try.
-
-The ease of the certification made me doubt they would be enough to validate, prove and demonstrate my learning.
-
-A practical project will achieve this better.
-
-Why English?
+Requirements
 ------------
 
-I've been coding, writing and communicating in English for 10 years, both at work and for personal code and documentation.
+* `Python3`
+* `pip`
+* `make`
 
-I continue to target English-based jobs.
+How to build
+------------
 
-Scope of the project
-====================
-
-Python and Python ecosystem
----------------------------
-
-1. Python language and standard lib
-2. Python desktop UI frameworks (`tkinter` and then migrating to `PySide6`)
-	* `tkinter` because it's part of certification requirements
-	* `PySide6` because I think QT is more advanced and I could use it for personal project and this package because it's the most up to date
-3. Python testing frameworks (standard `unittest`, migrating `Ward` and GUI testing framework)
-	* interrested in `Ward` as a different approach to testing syntax
-	* curious of how to handle migration
-4. Python web framework (`Flask`) exploration and practice
-	* popular
-	* I like it's advertised as lightweigth
-5. Pythonic and clean programming
-6. Documentation with [Sphinx](https://www.sphinx-doc.org/en/master/)
-	* THE doc tool for Python
-	* I want to experiment with [reStructuredText](https://docutils.sourceforge.io/rst.html)
-7. Pythonic SQL with [sqlite3](https://docs.python.org/3/library/sqlite3.html)
-	* curious of the pythonic way for SQL
-	* every backend app does SQL
-
-New technology exploration
---------------------------
-
-1. Experiment with Graph database usage (`GraphDB`?, `Neo4J`?)
-	* I'm proficient with relational, practitioner with document, never used graph
-2. Project management with a tool I don't know: [linear](https://linear.app)
-	* get out of confort-zone
-3. CI/CD with [Dagger](https://dagger.io/) on Circle-CI: https://docs.dagger.io/integrations/592501/circleci
-	* [KISS](https://fr.wikipedia.org/wiki/Principe_KISS) starting with Github actions
-	* Circle-CI seem to be quite popular and I've seen it on Job posting
-	* Dagger's concept is pretty could (and Python-based)
-
-Architecting demonstration
---------------------------
-
-Evolves the program from a command line Proof-of-concept, to a GUI-based desktop app, to a server-based monolith program app, to a browser-based program, to a scaling SAAS service with microservices:
-
-1. explore and practice the whole variety of `Python` based programs
-2. demonstrate and practice architecting skills at all stages and handling migrations
+1. `make venv`
+2. `source .venv/bin/activate`
+3. `make install`
+4 `make test`
 
 
+How to run and develop
+----------------------
 
-Work and time management
-========================
+1. `pip install -e`
+2. `pylms`
 
-Pomodoro
---------
+Code quality
+------------
 
-Apply the [Pomodoro Technique](https://en.wikipedia.org/wiki/Pomodoro_Technique) for time management.
+* code formatted with [`black`](https://black.readthedocs.io/en/stable/)
+* unit tested with `unittest` and `pytest`
+* code quality asserted with [SonarCloud](https://sonarcloud.io/project/overview?id=lesaint_PyLMS)
 
-I'll be using [Pomatez](https://github.com/zidoro/pomatez) as a Pomodoro tool.
+Licence
+=======
 
-I'll work in rounds of 25 minutes, sets of 4 rounds in a row, 5 minutes breaks in between.
-
-This implies a realistic 2 sets a day target.
-
-Sprint simulation
------------------
-
-I intent to simulate a day with one 25 minutes round and weekly sprints with a set of 4 rounds:
-
-* ensure the project is fast-paced, quickly beneficial and doesn't last forever
-* push the timebox approach and the feeling of urgency I practiced for 9 years to a limit and see what happens
-
-
-Health, work and work-balance benefits
---------------------------------------
-
-Additional reasons to use the Pomodoro technique:
-
-* Force me to take breaks:
-	* ease on my eyes getting impacted by all these years looking at a computer screen
-	* fight the impacts of the sitting position
-* Focus on work and use breaks for the small home related stuff
-* Become an advanced practitioner of the technique so that I'm really able to use it at work once I get back on a job (previous attempts in the past weren't successful)
-
-Project management
-==================
-
-Tooling
--------
-
-This project is an opportunity to experiment with a new tool: [linear](https://linear.app).
-
-It appears to have (to confirm with practice):
-
-* a full keyboard user interface
-* concepts different from Jira for project management (circle?)
-* integration with Github for issue workflow
-* a roadmap feature to draw and track the project's steps and milestones
-* free usage
-
-
+GNU GENERAL PUBLIC LICENSE


### PR DESCRIPTION
# WHY

We should demonstrate that the project is working and how to use it, right from the beginning of reading README.md

# WHAT

* change `README.md`
* move project rationale and approach to a dedicated md file and link it from `README.md`
* include the license in `README.md`