### PR TITLE
PYL-31 enable coverage analysis in SonarCloud

### DIFF
--- a/.github/workflows/pylms-build.yml
+++ b/.github/workflows/pylms-build.yml
@@ -1,15 +1,19 @@
 name: PyLMS CI
-
-on: [ push ] 
-
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 permissions:
   contents: read
-
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
@@ -24,6 +28,11 @@ jobs:
     - name: tests
       run: |
         make test
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     - name: build
       run: |
         make build

--- a/.github/workflows/pylms-build.yml
+++ b/.github/workflows/pylms-build.yml
@@ -27,7 +27,7 @@ jobs:
           make check-format
     - name: tests
       run: |
-        make test
+        make test-ci
     - name: SonarCloud Scan
       uses: SonarSource/sonarcloud-github-action@master
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 # PyLMS
 persons.db
 relationships.db
+coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+coverage_threshold = 75
+
 build: format test
 	python3 -m pip install --upgrade setuptools wheel build
 	python3 -m build
@@ -8,9 +10,14 @@ check-format:
 format:
 	python3 -m black src/ tests/
 
-test:
+test-run:
 	coverage run --branch -m pytest
-	coverage report --fail-under=75 -m
+
+test: test-run
+	coverage report --fail-under=$(coverage_threshold) --show-missing
+
+test-ci: test-run
+	coverage xml --fail-under=$(coverage_threshold)
 	
 venv: 
 	python3 -m venv .venv

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,5 +12,6 @@ sonar.tests=tests
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
-# Coverage
+# Python configuration
+sonar.python.version=3.11
 sonar.python.coverage.reportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,3 +11,6 @@ sonar.tests=tests
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
+
+# Coverage
+sonar.python.coverage.reportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=lesaint_PyLMS
+sonar.organization=lesaint
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=PyLMS
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=src
+sonar.tests=tests
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
# WHY

The badge would look good 😀 

Min coverage of 75% is already enforced with coverage in the CI but it's too bad not having the actual value in  SonarCloud.

# WHAT

* switch to CI-based analysis to have coverage computed when running SonarCloud analysis
* make coverage threshold consistent in makefile and SonarCloud

# HOW

* code coverage tuned by creating a custom Quality Gate in SonarCloud
* in CI, generate a `coverage.xml` file. use a specific Makefile target `test-ci` and ensure threshold stays consistent with target `test` using a Makefile variable
* switch coverage to relative paths (done in #20 )