### PR TITLE
PYL-36 show the right alias for sex of the person when sex is set

### DIFF
--- a/src/pylms/cli.py
+++ b/src/pylms/cli.py
@@ -19,7 +19,7 @@ class CLI(IOs, EventListener):
     @staticmethod
     def _show_relationship_of(*, relationship: Relationship, person: Person) -> None:
         other = relationship.right if relationship.left == person else relationship.left
-        print(f"    -> {relationship.repr_for(person)} de ({other.person_id}) {other}")
+        print(f"    -> {relationship.repr_for(person)} ({other.person_id}) {other}")
 
     def list_persons(self, resolved_persons: list[(Person, list[Relationship])]) -> None:
         if resolved_persons:

--- a/src/pylms/python_utils.py
+++ b/src/pylms/python_utils.py
@@ -1,0 +1,23 @@
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def require_not_none(v: T, message: str) -> T:
+    """
+    Raise ValueError with message if v is not None, otherwise return v
+    """
+    if v is None:
+        raise ValueError(message)
+    return v
+
+
+def first_not_none(*args: T | None) -> T:
+    """
+    :return: the first parameter that is not None
+    :raises: ValueError if no parameter or all are None
+    """
+    for t in args:
+        if t is not None:
+            return t
+    raise ValueError("At least one parameter must be not None")

--- a/tests/pylms/cli_test.py
+++ b/tests/pylms/cli_test.py
@@ -167,7 +167,7 @@ class TestDeletingRelationship:
     def test_left_person(self, mock_hit_enter, mock_print):
         person1 = Person(1, "Seb", "King")
         person2 = Person(2, "Mario", "Bros")
-        rld = RelationshipDefinition(name="rld")
+        rld = RelationshipDefinition(name="rld de")
         rl1 = Relationship(person1, person2, rld)
 
         under_test.deleting_relationship(rl1, person1)

--- a/tests/pylms/core_test.py
+++ b/tests/pylms/core_test.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from pylms.pylms import Person
 from pylms.pylms import PersonIdGenerator
 from unittest.mock import patch
-from pylms.core import RelationshipDefinition, Relationship, Sex, MALE, FEMALE
+from pylms.core import RelationshipDefinition, Relationship, RelationshipAlias
+from pylms.core import Sex, MALE, FEMALE
 from pytest import raises, mark
 
 
@@ -65,8 +66,8 @@ class TestRelationship:
     person3 = Person(3, "Diana", "King")
     definition = RelationshipDefinition(
         name="FooDef",
-        person_left_repr="LeftFoo",
-        person_right_repr="RightFoo",
+        person_left_default_repr="LeftFoo",
+        person_right_default_repr="RightFoo",
     )
     relationship = Relationship(person_left=person1, person_right=person2, definition=definition)
 
@@ -103,3 +104,91 @@ class TestPersonSex:
     def test_setter_fails_if_sex_is_not_constant(self, person, non_constant_sex):
         with raises(ValueError, match="Sex must be either constant MALE or FEMALE"):
             Person(person_id=1, firstname="foo", lastname="bar", sex=non_constant_sex)
+
+
+class TestRelationshipReprFor:
+    person1 = Person(1, "John", "Doe")
+    person2 = Person(2, "Alita", "Donut")
+    rl_def = RelationshipDefinition(name="rl")
+    rl1 = Relationship(person_left=person1, person_right=person2, definition=rl_def)
+
+    def test_raise_value_error_if_neither_left_nor_right(self):
+        other_person = Person(12, "other", "unknown")
+        with raises(ValueError, match="other unknown is neither the left nor right person of this rl relationship"):
+            self.rl1.repr_for(other_person)
+
+    @patch.object(rl_def, "left_repr")
+    @patch.object(rl_def, "right_repr")
+    def test_calls_left_repr_for_left_person(self, mock_right_repr, mock_left_repr):
+        self.rl1.repr_for(self.person1)
+
+        mock_left_repr.assert_called_once_with(self.person1)
+        assert mock_right_repr.call_count == 0
+
+    @patch.object(rl_def, "left_repr")
+    @patch.object(rl_def, "right_repr")
+    def test_calls_right_repr_for_right_person(self, mock_right_repr, mock_left_repr):
+        self.rl1.repr_for(self.person2)
+
+        assert mock_left_repr.call_count == 0
+        mock_right_repr.assert_called_once_with(self.person2)
+
+
+class TestRelationshipDefinitionRepr:
+    person_no_sex = Person(1, "Camilla")
+    person_male = Person(1, "Camille", sex=MALE)
+    person_female = Person(1, "Pita", sex=FEMALE)
+    rld_name = "foo"
+    left_default = "bar"
+    right_default = "donut"
+    rld_no_default_no_alias = RelationshipDefinition(name=rld_name)
+    rld_defaults_no_alias = RelationshipDefinition(
+        name=rld_name, person_left_default_repr=left_default, person_right_default_repr=right_default
+    )
+    rld_defaults_all_aliases_variants = RelationshipDefinition(
+        name=rld_name,
+        person_left_default_repr=left_default,
+        person_right_default_repr=right_default,
+        aliases=[
+            RelationshipAlias("no_sex_forward", reverse=False),
+            RelationshipAlias("no_sex_reverse", reverse=True),
+            RelationshipAlias("left_male_forward", left_person_sex=MALE, reverse=False),
+            RelationshipAlias("left_female_forward", left_person_sex=FEMALE, reverse=False),
+            RelationshipAlias("left_male_reverse", left_person_sex=MALE, reverse=True),
+            RelationshipAlias("left_female_reverse", left_person_sex=FEMALE, reverse=True),
+            RelationshipAlias("right_male_forward", right_person_sex=MALE, reverse=False),
+            RelationshipAlias("right_female_forward", right_person_sex=FEMALE, reverse=False),
+            RelationshipAlias("right_male_reverse", right_person_sex=MALE, reverse=True),
+            RelationshipAlias("right_female_reverse", right_person_sex=FEMALE, reverse=True),
+        ],
+    )
+
+    def test_right_repr_return_if_no_alias_nor_default(self):
+        assert self.rld_no_default_no_alias.right_repr(self.person_no_sex) == self.rld_name
+
+    def test_left_repr_return_if_no_alias_nor_default(self):
+        assert self.rld_no_default_no_alias.left_repr(self.person_no_sex) == self.rld_name
+
+    def test_right_repr_return_right_default_if_no_alias(self):
+        assert self.rld_defaults_no_alias.right_repr(self.person_no_sex) == self.right_default
+
+    def test_left_repr_return_right_default_if_no_alias(self):
+        assert self.rld_defaults_no_alias.left_repr(self.person_no_sex) == self.left_default
+
+    def test_left_repr_return_alias_forward_no_sex(self):
+        assert self.rld_defaults_all_aliases_variants.left_repr(self.person_no_sex) == "no_sex_forward"
+
+    def test_right_repr_return_alias_reverse_no_sex(self):
+        assert self.rld_defaults_all_aliases_variants.right_repr(self.person_no_sex) == "no_sex_reverse"
+
+    def test_left_repr_return_alias_forward_male(self):
+        assert self.rld_defaults_all_aliases_variants.left_repr(self.person_male) == "left_male_forward"
+
+    def test_right_repr_return_alias_reverse_male(self):
+        assert self.rld_defaults_all_aliases_variants.right_repr(self.person_male) == "left_male_reverse"
+
+    def test_left_repr_return_alias_forward_female(self):
+        assert self.rld_defaults_all_aliases_variants.left_repr(self.person_female) == "left_female_forward"
+
+    def test_right_repr_return_alias_reverse_female(self):
+        assert self.rld_defaults_all_aliases_variants.right_repr(self.person_female) == "left_female_reverse"

--- a/tests/pylms/pylms_protected_test.py
+++ b/tests/pylms/pylms_protected_test.py
@@ -75,8 +75,8 @@ relationship_definition_1 = RelationshipDefinition(
         RelationshipAlias("bbb"),
         RelationshipAlias("ccc"),
     ],
-    person_left_repr="leftFoo",
-    person_right_repr="rightFoo",
+    person_left_default_repr="leftFoo",
+    person_right_default_repr="rightFoo",
 )
 relationship_definition_2 = RelationshipDefinition(
     name="bar",
@@ -85,7 +85,7 @@ relationship_definition_2 = RelationshipDefinition(
         RelationshipAlias("22"),
         RelationshipAlias("33"),
     ],
-    person_left_repr="leftBar",
+    person_left_default_repr="leftBar",
 )
 relationship_definition_3 = RelationshipDefinition(
     name="acme",

--- a/tests/pylms/test_python_utils.py
+++ b/tests/pylms/test_python_utils.py
@@ -1,0 +1,62 @@
+import random
+
+from pylms.python_utils import first_not_none, require_not_none
+from pytest import raises, fixture
+from random import randint
+
+OBJECTS = [1, 2, "str1", "str2", 3.4, 4.3, ["A", "b"], [3, 7.9]]
+
+
+@fixture
+def not_none_var():
+    return OBJECTS[randint(0, len(OBJECTS) - 1)]
+
+
+class TestFirstNotNone:
+    error_message = "At least one parameter must be not None"
+
+    @staticmethod
+    def _other_var(not_none_var):
+        temp = OBJECTS[:]
+        temp.remove(not_none_var)
+        return temp[randint(0, len(temp) - 1)]
+
+    @fixture
+    def any_number_of_none(self):
+        return [None for _ in range(randint(1, 5))]
+
+    @fixture
+    def more_than_one_none(self):
+        return [None for _ in range(randint(2, 5))]
+
+    def test_raises_value_error_if_no_parameter(self):
+        with raises(ValueError, match=self.error_message):
+            first_not_none()
+
+    def test_raises_value_error_if_only_none_parameter(self):
+        with raises(ValueError, match=self.error_message):
+            first_not_none(None)
+
+    def test_raises_value_error_if_only_none_parameters(self, more_than_one_none):
+        with raises(ValueError, match=self.error_message):
+            first_not_none(*more_than_one_none)
+
+    def test_return_first_not_none_parameter(self, not_none_var, any_number_of_none):
+        other_var = self._other_var(not_none_var)
+
+        assert first_not_none(not_none_var) is not_none_var
+        assert first_not_none(not_none_var, other_var) is not_none_var
+        assert first_not_none(*any_number_of_none, not_none_var) is not_none_var
+        assert first_not_none(*any_number_of_none, not_none_var, other_var) is not_none_var
+        assert first_not_none(*any_number_of_none, not_none_var, *any_number_of_none, other_var) is not_none_var
+
+
+class TestRequireNotNone:
+    message: str = "This is the expected message"
+
+    def test_return_object_if_not_none(self, not_none_var):
+        assert require_not_none(not_none_var, self.message) == not_none_var
+
+    def test_raises_value_error_with_specified_message_if_none(self):
+        with raises(ValueError, match=self.message):
+            require_not_none(None, self.message)


### PR DESCRIPTION
# WHY

Currently, even if sex is set on a Person, a relationship is displayed indifferently: 
```
(19)  MALE John (2024-4-29 22-11-17)
    -> parent de (20) Peter
(20)  MALE Peter (2024-5-6 11-5-54)
    -> enfant de (19) John
```

# WHAT

When the relationship supports it and the sex of the alias-left-hand-side person is known, display the relationship appropriately:

* `parent de` -> `père de` ou `mère de`
* `enfant de` -> `fils de` ou `fille de`
* `copain de` -> `copain de` ou `copine de`

# HOW

* `RelationshipDefinition.left_repr` and `RelationshipDefinition.right_repr` now account for the sex of the person: searching for a `RelationshipDefinitionAlias` that has a `left_person_sex` of the same sex (if sex is `None`, `left_person_sex` must be `None` too) and returning its `name`
* `RelationshipDefinition.right_repr` searches for a reverse alias, while `RelationshipDefinition.left_repr` searches for a forward one
* if no alias is found, `_person_left_default_repr` or `_person_right_default_repr` is returned (if not None) respectively
* In the last resort, the `name` of the `RelationshipDefinition` is returned, ensuring a `str` is always returned