### PR TITLE
PYL-37 search person by a word in first name and/or last name case

### DIFF
--- a/src/pylms/__main__.py
+++ b/src/pylms/__main__.py
@@ -3,7 +3,8 @@
 import logging
 from sys import argv
 import pylms.pylms
-from pylms.pylms import list_persons, store_person, update_person, delete_person, link_persons, ExitPyLMS
+from pylms.pylms import list_persons, store_person, update_person, delete_person, link_persons, search_persons
+from pylms.pylms import ExitPyLMS
 from pylms.cli import CLI
 
 
@@ -35,6 +36,10 @@ def _read_and_execute_commands() -> None:
 
     if argv[1].lower() == "link":
         _command_link(argv_length)
+        return
+
+    if argv[1].lower() == "search":
+        _command_search(argv_length)
         return
 
     _command_create(argv_length)
@@ -83,6 +88,13 @@ def _command_link(argv_length: int) -> None:
 
     natural_link_request = " ".join(argv[2:])
     link_persons(natural_link_request)
+
+
+def _command_search(argv_length: int) -> None:
+    if argv_length != 3:
+        print(f"Wrong number of arguments ({argv_length})")
+    natural_search_request = " ".join(argv[2:])
+    search_persons(natural_search_request)
 
 
 if __name__ == "__main__":

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -18,7 +18,7 @@ class IOs(ABC):
         pass
 
     @abstractmethod
-    def list_persons(self, persons: list[Person]) -> None:
+    def list_persons(self, persons: list[(Person, list[Relationship])]) -> None:
         pass
 
     @abstractmethod

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -72,7 +72,7 @@ def list_persons() -> None:
 
 
 def _select_person(pattern: str) -> Person | None:
-    persons = _search_person(pattern)
+    persons = _search_persons(pattern)
     if not persons:
         return
 
@@ -92,7 +92,7 @@ def update_person(pattern: str) -> None:
     storage.update_person(updated_person)
 
 
-def _search_person(pattern: str) -> list[Person]:
+def _search_persons(pattern: str) -> list[Person]:
     persons = storage.read_persons()
 
     res = []

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -56,8 +56,8 @@ class EventListener(ABC):
         pass
 
 
-ios: IOs
-events: EventListener
+ios: IOs | None = None
+events: EventListener | None = None
 
 
 def list_persons() -> None:

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -239,3 +239,29 @@ def link_persons(natural_language_link_request: str) -> None:
         definition=link_request.definition,
     )
     storage.store_relationships(relationships + [relationship])
+
+
+def search_persons(pattern: str) -> None:
+    person_hits = _search_persons(pattern)
+
+    if not person_hits:
+        logger.info(f'No match for "{pattern}".')
+        return
+
+    persons = storage.read_persons()
+
+    resolved_persons = []
+    if persons:
+        relationships = storage.read_relationships(persons)
+
+        def p_filter(p: Person) -> bool:
+            return p in person_hits
+
+        def rl_filter(p: Person, _: Relationship) -> bool:
+            return p in person_hits
+
+        resolved_persons = resolve_persons(
+            persons=persons, relationships=relationships, person_filter=p_filter, relationship_filter=rl_filter
+        )
+
+    ios.list_persons(resolved_persons)

--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -92,11 +92,6 @@ def update_person(pattern: str) -> None:
     storage.update_person(updated_person)
 
 
-def search_person(pattern: str) -> None:
-    for person in _search_person(pattern):
-        ios.show_person(person)
-
-
 def _search_person(pattern: str) -> list[Person]:
     persons = storage.read_persons()
 

--- a/tests/pylms/pylms_protected_test.py
+++ b/tests/pylms/pylms_protected_test.py
@@ -1,13 +1,13 @@
 from pylms.core import Person
 from pylms.core import RelationshipDefinition, RelationshipAlias
-from pylms.pylms import _search_person, _select_person
+from pylms.pylms import _search_persons, _select_person
 from pylms.pylms import _parse_nl_link_request
 from pytest import mark
 from unittest.mock import patch, call
 
 
 @patch("pylms.pylms.storage")
-def test_search_person(mock_storage):
+def test_search_persons(mock_storage):
     persons = [
         Person(3, "Bob"),
         Person(1, "Seb"),
@@ -15,17 +15,17 @@ def test_search_person(mock_storage):
     ]
     mock_storage.read_persons.return_value = persons
 
-    assert _search_person("bob") == [persons[0]]
-    assert _search_person("BOB") == [persons[0]]
-    assert _search_person("eb") == [persons[1], persons[2]]
-    assert _search_person("bob") == [persons[0]]
-    assert _search_person("foo") == []
+    assert _search_persons("bob") == [persons[0]]
+    assert _search_persons("BOB") == [persons[0]]
+    assert _search_persons("eb") == [persons[1], persons[2]]
+    assert _search_persons("bob") == [persons[0]]
+    assert _search_persons("foo") == []
 
 
 class Test_select_person:
 
     @patch("builtins.print")
-    @patch("pylms.pylms._search_person")
+    @patch("pylms.pylms._search_persons")
     def test_no_match(self, mock_search_person, mock_print):
         mock_search_person.return_value = []
 
@@ -37,7 +37,7 @@ class Test_select_person:
         assert mock_print.call_count == 0
 
     @patch("builtins.print")
-    @patch("pylms.pylms._search_person")
+    @patch("pylms.pylms._search_persons")
     def test_one_match(self, mock_search_person, mock_print):
         person = Person(123, "John", "Wick")
         mock_search_person.return_value = [person]
@@ -50,7 +50,7 @@ class Test_select_person:
         assert mock_print.call_count == 0
 
     @patch("pylms.pylms.ios.select_person")
-    @patch("pylms.pylms._search_person")
+    @patch("pylms.pylms._search_persons")
     def test_several_matches(self, mock_search_person, mock_select_person):
         persons = [
             Person(3, "Bob"),

--- a/tests/pylms/pymls_test.py
+++ b/tests/pylms/pymls_test.py
@@ -1,6 +1,5 @@
-from datetime import datetime
 from pylms.core import Person
-from pylms.pylms import list_persons, store_person, search_person, update_person, delete_person, link_persons
+from pylms.pylms import list_persons, store_person, update_person, delete_person, link_persons
 from pylms.pylms import LinkRequest, Relationship, RelationshipDefinition, RelationshipAlias
 from unittest.mock import patch, call
 
@@ -113,34 +112,6 @@ class TestListPersons:
         mock_read_persons.assert_called_once_with()
         mock_read_relationships.assert_called_once_with(persons)
         mock_list_persons.assert_called_once_with([(person, []) for person in persons])
-
-
-class TestSearchPerson:
-    @patch("builtins.print")
-    @patch("pylms.pylms._search_person")
-    def test_search_person_no_result(self, mock_search_person, mock_print):
-        mock_search_person.return_value = []
-
-        search_person("p")
-
-        mock_search_person.assert_called_once_with("p")
-        assert mock_print.call_count == 0
-
-    @patch("pylms.pylms.ios.show_person")
-    @patch("pylms.pylms._search_person")
-    def test_search_person_results(self, mock_search_person, mock_show_person):
-        persons = [
-            Person(3, "Bob"),
-            Person(1, "Seb"),
-            Person(2, "MarioEb"),
-        ]
-        mock_search_person.return_value = persons
-
-        search_person("p")
-
-        mock_search_person.assert_called_once_with("p")
-        assert mock_show_person.call_count == 3
-        mock_show_person.assert_has_calls([call(person) for person in persons])
 
 
 class TestUpdatePerson:


### PR DESCRIPTION
# WHY

Listing all persons works but doesn't scale: it's a pain to read the list as soon as the tool contains more than a handful of persons.

We need to be able to search.

# WHAT

Search by a word in the first name and/or last name (case insensitive) is the simplest search feature to provide since it is already implemented and used to update or delete a person.

# HOW

`pylms search doe` displays the same output as `pylms` only showing the person (or persons) whose first name and/or last name contains  `doe`, and their relationships (unfiltered)