### PR TITLE
PYL-35 support search by relationship

### DIFF
--- a/src/pylms/__main__.py
+++ b/src/pylms/__main__.py
@@ -85,14 +85,17 @@ def _command_delete(argv_length: int) -> None:
 def _command_link(argv_length: int) -> None:
     if argv_length < 4:
         print(f"Too few arguments ({argv_length -1})")
+        return
 
     natural_link_request = " ".join(argv[2:])
     link_persons(natural_link_request)
 
 
 def _command_search(argv_length: int) -> None:
-    if argv_length != 3:
-        print(f"Wrong number of arguments ({argv_length})")
+    if argv_length < 3:
+        print(f"Too few arguments ({argv_length})")
+        return
+
     natural_search_request = " ".join(argv[2:])
     search_persons(natural_search_request)
 


### PR DESCRIPTION
# WHY

A common use case of search is to try and find a person (or persons) by their relationship to others.

eg.:

* `parent de Peter`
* `mère de Peter`
* `ami de Peter`

# WHAT

1. Search for the relationship that matches the query
2. Search for the person on the right-hand side (from the alias perspective) that matches the name (here Peter)
3. For the person (or persons) found, search for an occurrence of the relationship where the person is on the alias-right-hand side of the relationship
4. Display the alias-left-hand-side persons

# HOW

`pylms search` now supports either 1 word or 3 words

* if 1 word, do the tag-based search as described in #PYL-34
* if 3 words, do the new relationship search

`pylms search parent de Peter`

* Find the relationship with an alias equal (case-insensitive) to the 2 first words
    * if no relationship is found, log (INFO) `No match for "parent de Peter".` and stop
* Find one or more persons matching the 3rd word with the same method as for other commands
    * if no person is found, log INFO `No match for "parent de Peter".` and stop
* Filter the persons to only those with the relationship and with standing on the right-hand-side (or the left-hand-side if the alias is reversed)
    * if no person is left, log INFO `No match for "parent de Peter".` and stop
*  Display the left-hand-side persons (or right-hand-side if the alias is reversed) of these relationships

`pylms search père de Peter`

* same as above
* but since the alias `père de` has sex defined for the left person, only display the left-hand-side person that has sex defined AND matches the one of the relationship alias