### PR TITLE
PYL-38 make search the default command

### DIFF
--- a/src/pylms/__main__.py
+++ b/src/pylms/__main__.py
@@ -20,83 +20,92 @@ def main() -> None:
 
 
 def _read_and_execute_commands() -> None:
-    argv_length = len(argv)
+    args: list[str] = argv[1:]
 
-    if argv_length == 1:
+    if not args:
         _command_list()
         return
 
-    if argv[1].lower() == "update":
-        _command_update(argv_length)
+    command = args[0].lower()
+    if command == "create":
+        _command_create(args[1:])
         return
 
-    if argv[1].lower() == "delete":
-        _command_delete(argv_length)
+    if command == "update":
+        _command_update(args[1:])
         return
 
-    if argv[1].lower() == "link":
-        _command_link(argv_length)
+    if command == "delete":
+        _command_delete(args[1:])
         return
 
-    if argv[1].lower() == "search":
-        _command_search(argv_length)
+    if command == "link":
+        _command_link(args[1:])
         return
 
-    _command_create(argv_length)
+    _command_search(args)
 
 
 def _command_list() -> None:
     list_persons()
 
 
-def _command_create(argv_length: int) -> None:
-    if argv_length > 3:
-        print(f"Too many arguments ({argv_length - 1})")
+def _command_create(arguments: list[str]) -> None:
+    arguments_count = len(arguments)
+    if arguments_count < 1:
+        print(f"Too few arguments ({arguments_count})")
+        return
+    if arguments_count > 2:
+        print(f"Too many arguments ({arguments_count})")
         return
 
-    if argv_length == 2:
-        store_person(firstname=argv[1])
+    if arguments_count == 1:
+        store_person(firstname=arguments[0])
     else:
-        store_person(firstname=argv[1], lastname=argv[2])
+        store_person(firstname=arguments[0], lastname=arguments[1])
 
 
-def _command_update(argv_length: int) -> None:
-    if argv_length > 3:
-        print(f"Too many arguments ({argv_length - 1})")
+def _command_update(arguments: list[str]) -> None:
+    arguments_count = len(arguments)
+    if arguments_count > 1:
+        print(f"Too many arguments ({arguments_count})")
         return
 
-    if argv_length == 3:
-        update_person(pattern=argv[2])
-    else:
-        print(f"Missing search pattern")
-
-
-def _command_delete(argv_length: int) -> None:
-    if argv_length > 3:
-        print(f"Too many arguments ({argv_length - 1})")
-        return
-
-    if argv_length == 3:
-        delete_person(pattern=argv[2])
+    if arguments_count == 1:
+        update_person(pattern=arguments[0])
     else:
         print(f"Missing search pattern")
 
 
-def _command_link(argv_length: int) -> None:
-    if argv_length < 4:
-        print(f"Too few arguments ({argv_length -1})")
+def _command_delete(arguments: list[str]) -> None:
+    arguments_count = len(arguments)
+    if arguments_count > 1:
+        print(f"Too many arguments ({arguments_count})")
         return
 
-    natural_link_request = " ".join(argv[2:])
+    if arguments_count == 1:
+        delete_person(pattern=arguments[0])
+    else:
+        print(f"Missing search pattern")
+
+
+def _command_link(arguments: list[str]) -> None:
+    arguments_count = len(arguments)
+    if arguments_count < 2:
+        print(f"Too few arguments ({arguments_count})")
+        return
+
+    natural_link_request = " ".join(arguments)
     link_persons(natural_link_request)
 
 
-def _command_search(argv_length: int) -> None:
-    if argv_length < 3:
-        print(f"Too few arguments ({argv_length})")
+def _command_search(arguments: list[str]) -> None:
+    arguments_count = len(arguments)
+    if arguments_count < 1:
+        print(f"Too few arguments ({arguments_count})")
         return
 
-    natural_search_request = " ".join(argv[2:])
+    natural_search_request = " ".join(arguments)
     search_persons(natural_search_request)
 
 

--- a/tests/pylms/main_test.py
+++ b/tests/pylms/main_test.py
@@ -2,86 +2,216 @@ from unittest.mock import patch, call
 from pylms import __main__
 from pytest import fixture
 from random import randint
+from typing import ContextManager
+
+COMMAND_CREATE = "create"
+COMMAND_UPDATE = "update"
+COMMAND_DELETE = "delete"
+COMMAND_LINK = "link"
+
 
 program_name = "pylms"
 
 
-def random_maj_char():
+def random_maj_char() -> chr:
     return chr(randint(ord("A"), ord("Z")))
 
 
 # Fixtures
 @fixture
-def no_arguments():
+def no_arguments() -> list[str]:
     return []
 
 
 @fixture
-def one_argument():
+def one_argument() -> list[str]:
     return [random_maj_char()]
 
 
 @fixture
-def two_arguments():
+def two_arguments() -> list[str]:
     return [random_maj_char(), random_maj_char()]
 
 
 @fixture
-def more_than_two_arguments():
-    return [program_name] + [random_maj_char() for _ in range(1, 3 + randint(0, 5))]
+def more_than_one_argument() -> list[str]:
+    return [random_maj_char() for _ in range(0, 2 + randint(0, 5))]
 
 
-def mock_argv(arguments_list):
+@fixture
+def more_than_two_arguments() -> list[str]:
+    return [random_maj_char() for _ in range(0, 3 + randint(0, 5))]
+
+
+def mock_argv(arguments_list: list[str]) -> ContextManager[any]:
     return patch("pylms.__main__.argv", [program_name] + arguments_list)
 
 
 @patch("builtins.print")
-@patch("pylms.__main__.store_person")
 @patch("pylms.__main__.list_persons")
-def test_main_no_argument(mock_list_persons, mock_store_person, mock_print, no_arguments):
+def test_main_no_argument(mock_list_persons, mock_print, no_arguments):
     with mock_argv(no_arguments):
         __main__.main()
 
-        mock_list_persons.assert_called_with()
-        assert mock_list_persons.call_count == 1
-        assert mock_store_person.call_count == 0
+        mock_list_persons.assert_called_once_with()
         assert mock_print.call_count == 0
 
 
 @patch("builtins.print")
-@patch("pylms.__main__.store_person")
-@patch("pylms.__main__.list_persons")
-def test_main_one_argument(mock_list_persons, mock_store_person, mock_print, one_argument):
+@patch("pylms.__main__.search_persons")
+def test_main_one_argument(mock_search_person, mock_print, one_argument):
     with mock_argv(one_argument):
         __main__.main()
 
-        mock_store_person.assert_called_with(firstname=one_argument[0])
-        assert mock_store_person.call_count == 1
-        assert mock_list_persons.call_count == 0
+        mock_search_person.assert_called_once_with(one_argument[0])
         assert mock_print.call_count == 0
 
 
 @patch("builtins.print")
-@patch("pylms.__main__.store_person")
-@patch("pylms.__main__.list_persons")
-def test_main_two_arguments(mock_list_persons, mock_store_person, mock_print, two_arguments):
+@patch("pylms.__main__.search_persons")
+def test_main_two_arguments(mock_search_person, mock_print, two_arguments):
     with mock_argv(two_arguments):
         __main__.main()
 
-        mock_store_person.assert_called_with(firstname=two_arguments[0], lastname=two_arguments[1])
-        assert mock_store_person.call_count == 1
-        assert mock_list_persons.call_count == 0
+        mock_search_person.assert_called_once_with(two_arguments[0] + " " + two_arguments[1])
+        assert mock_print.call_count == 0
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.search_persons")
+def test_main_three_arguments(mock_search_person, mock_print, more_than_two_arguments):
+    with mock_argv(more_than_two_arguments):
+        __main__.main()
+
+        mock_search_person.assert_called_once_with(" ".join(more_than_two_arguments))
         assert mock_print.call_count == 0
 
 
 @patch("builtins.print")
 @patch("pylms.__main__.store_person")
-@patch("pylms.__main__.list_persons")
-def test_main_three_arguments(mock_list_persons, mock_store_person, mock_print, more_than_two_arguments):
-    with mock_argv(more_than_two_arguments):
+def test_create_no_argument(mock_store_person, mock_print, no_arguments):
+    with mock_argv([COMMAND_CREATE] + no_arguments):
         __main__.main()
 
-        mock_print.assert_called_with(f"Too many arguments ({len(more_than_two_arguments)})")
         assert mock_store_person.call_count == 0
-        assert mock_list_persons.call_count == 0
-        assert mock_print.call_count == 1
+        mock_print.assert_called_once_with("Too few arguments (0)")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.store_person")
+def test_create_one_argument(mock_store_person, mock_print, one_argument):
+    with mock_argv([COMMAND_CREATE] + one_argument):
+        __main__.main()
+
+        mock_store_person.assert_called_once_with(firstname=one_argument[0])
+        assert mock_print.call_count == 0
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.store_person")
+def test_create_two_arguments(mock_store_person, mock_print, two_arguments):
+    with mock_argv([COMMAND_CREATE] + two_arguments):
+        __main__.main()
+
+        mock_store_person.assert_called_once_with(firstname=two_arguments[0], lastname=two_arguments[1])
+        assert mock_print.call_count == 0
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.store_person")
+def test_create_more_than_two_arguments(mock_store_person, mock_print, more_than_two_arguments):
+    with mock_argv([COMMAND_CREATE] + more_than_two_arguments):
+        __main__.main()
+
+        assert mock_store_person.call_count == 0
+        mock_print.assert_called_once_with(f"Too many arguments ({len(more_than_two_arguments)})")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.update_person")
+def test_update_no_argument(mock_update_person, mock_print, no_arguments):
+    with mock_argv([COMMAND_UPDATE] + no_arguments):
+        __main__.main()
+
+        assert mock_update_person.call_count == 0
+        mock_print.assert_called_once_with("Missing search pattern")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.update_person")
+def test_update_one_argument(mock_update_person, mock_print, one_argument):
+    with mock_argv([COMMAND_UPDATE] + one_argument):
+        __main__.main()
+
+        mock_update_person.assert_called_once_with(pattern=one_argument[0])
+        assert mock_print.call_count == 0
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.update_person")
+def test_update_more_than_one_argument(mock_update_person, mock_print, more_than_one_argument):
+    with mock_argv([COMMAND_UPDATE] + more_than_one_argument):
+        __main__.main()
+
+        assert mock_update_person.call_count == 0
+        mock_print.assert_called_once_with(f"Too many arguments ({len(more_than_one_argument)})")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.delete_person")
+def test_delete_no_argument(mock_delete_person, mock_print, no_arguments):
+    with mock_argv([COMMAND_DELETE] + no_arguments):
+        __main__.main()
+
+        assert mock_delete_person.call_count == 0
+        mock_print.assert_called_once_with("Missing search pattern")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.delete_person")
+def test_delete_one_argument(mock_delete_person, mock_print, one_argument):
+    with mock_argv([COMMAND_DELETE] + one_argument):
+        __main__.main()
+
+        mock_delete_person.assert_called_once_with(pattern=one_argument[0])
+        assert mock_print.call_count == 0
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.delete_person")
+def test_delete_more_than_one_argument(mock_delete_person, mock_print, more_than_one_argument):
+    with mock_argv([COMMAND_DELETE] + more_than_one_argument):
+        __main__.main()
+
+        assert mock_delete_person.call_count == 0
+        mock_print.assert_called_once_with(f"Too many arguments ({len(more_than_one_argument)})")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.link_persons")
+def test_link_no_argument(mock_link_persons, mock_print, no_arguments):
+    with mock_argv([COMMAND_LINK] + no_arguments):
+        __main__.main()
+
+        assert mock_link_persons.call_count == 0
+        mock_print.assert_called_once_with("Too few arguments (0)")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.link_persons")
+def test_link_one_argument(mock_link_persons, mock_print, one_argument):
+    with mock_argv([COMMAND_LINK] + one_argument):
+        __main__.main()
+
+        assert mock_link_persons.call_count == 0
+        mock_print.assert_called_once_with("Too few arguments (1)")
+
+
+@patch("builtins.print")
+@patch("pylms.__main__.link_persons")
+def test_link_two_arguments(mock_link_persons, mock_print, two_arguments):
+    with mock_argv([COMMAND_LINK] + two_arguments):
+        __main__.main()
+
+        mock_link_persons.assert_called_once_with(two_arguments[0] + " " + two_arguments[1])
+        assert mock_print.call_count == 0


### PR DESCRIPTION
# WHY

* `pylms` displays all persons and their relationships.
* `pylms search blabla` displays some persons and their relationships.
* `pylms whatever`  creates a new contact.

This has a few issues:

1. this is error-prone: One can easily forget to add the search the keyword when attempting to filter the list of persons and end up creating a Person called `blabla`
2. one can reasonably assume that users will more frequently search for persons than create some. Unfortunately, this more regularly used command requires extra keystroke to be run
3. minor: creating a person whose first name is `search`, `link`, `update` or `delete` is not possible

# WHAT

Make search the default command and make create an explicit one from now on