### PR TITLE
Upgrade makefile to use venv autonomously + target Python 3.10 rather than 3.11

### DIFF
--- a/.github/workflows/pylms-build.yml
+++ b/.github/workflows/pylms-build.yml
@@ -18,10 +18,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        make install
     - name: check-format
       run: |
           make check-format

--- a/.github/workflows/pylms-build.yml
+++ b/.github/workflows/pylms-build.yml
@@ -14,10 +14,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-    - name: Set up Python 3.11
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.10"
     - name: check-format
       run: |
           make check-format

--- a/.github/workflows/pylms-build.yml
+++ b/.github/workflows/pylms-build.yml
@@ -31,6 +31,14 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
     - name: build
       uses: coactions/setup-xvfb@v1.0.1
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,61 @@
-coverage_threshold = 75
+coverage_threshold=75
+
+help:
+	@echo 'Makefile for a PyLMS                                                                     '
+	@echo '                                                                                         '
+	@echo 'Usage:                                                                                   '
+	@echo '   make venv            initialize venv                                                  '
+	@echo '   make venvclean       delete venv                                                      '
+	@echo '   make check-format    checks whether any Python file format is non compliant           '
+	@echo '   make format          format all Python files with Black                               '
+	@echo '   make test            run tests                                                        '
+	@echo '   make test-ci         run tests in CI environment (generates XML coverage report file) '
+	@echo '   make build           build artifacts                                                  '
+	@echo '                                                                                         '
+
+
+# use .ONESHELL to activate venv and use it across a recipe without adding it before each command (source: https://stackoverflow.com/a/55404948)
+.ONESHELL:
+
+VENV_DIR=.venv
+# source: https://stackoverflow.com/a/73837995
+ACTIVATE_VENV:=. $(VENV_DIR)/bin/activate
+
+$(VENV_DIR)/touchfile: requirements.txt
+	test -d "$(VENV_DIR)" || python3 -m venv "$(VENV_DIR)"
+	$(ACTIVATE_VENV)
+	pip install --upgrade --requirement requirements.txt
+	pip install --editable .
+	touch "$(VENV_DIR)/touchfile"
+
+venv: $(VENV_DIR)/touchfile
+
+venvclean:
+	rm -rf $(VENV_DIR)
 
 build: format test
+	$(ACTIVATE_VENV)
 	python3 -m pip install --upgrade setuptools wheel build
 	python3 -m build
 
-check-format:
+check-format: venv
+	$(ACTIVATE_VENV)
 	python3 -m black --check src/ tests/
 
-format:
+format: venv
+	$(ACTIVATE_VENV)
 	python3 -m black src/ tests/
 
-test-run:
+test-run: venv
+	$(ACTIVATE_VENV)
 	coverage run --branch -m pytest
 
 test: test-run
+	$(ACTIVATE_VENV)
 	coverage report --fail-under=$(coverage_threshold) --show-missing
 
 test-ci: test-run
+	$(ACTIVATE_VENV)
 	coverage xml --fail-under=$(coverage_threshold)
-	
-venv: 
-	python3 -m venv .venv
-	@echo "Now run source .venv/bin/activate"
 
-install:
-	pip install -r requirements.txt
-	pip install --editable .
-
-.PHONY: test format build
+.PHONY: venv venvclean help check-format format test test-ci build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py311']
+target-version = ['py310']
 
 [tool.coverage.run]
 source = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,6 @@ sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 
 # Python configuration
-sonar.python.version=3.11
+sonar.python.version=3.10
 sonar.python.coverage.reportPaths=coverage.xml
 


### PR DESCRIPTION
* I now know how to activate venv in Makefile recipes (see https://www.javatronic.fr/posts/2024/05/04/activate-venv-in-makefile/)
* I've been using Python 3.10 in dev. Rather than upgrading my dev env, make build, CI and Sonar scan consistent and use 3.10 too