### PR TITLE
PYL-33 can had tags to a person

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ $ pylms # list all persons (fist name, last name, sex and id) and their relation
 $ pylms john # search a person (or persons) which first name and/or last name contain 'john'
 $ pylms create John Doe # create a person with first name 'John' and last name 'Doe'
 $ pylms create John # create a person with first name 'John' 
+$ pylms update John # to interactively set the first/last name or the tags of the person matching 'John'
+$ pylms update John Doe # to interactively set the first/last name or the tags of the person matching 'John Doe'
 $ pylms link John Doe père de Tony Doe # create a relationship between person matching 'John Doe' and another person matching 'Tony Doe'
 $ pylms link John père de Tony # same, only searching with 'John' and 'Tony'
 $ pylms delete John # delete the person matching 'John'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ PyLMS
 
 `PyLMS` is a utility to cope with my personal difficulty to remember people's names and relationships, to me and between each other.
 
-* `Py` stands for `Python`: because this is a learning and practicing technical project: see [Learning with practice](#learning-through-practice)
+* `Py` stands for `Python`: because this is a learning and practicing project: see [Learning through practice](#learning-through-practice)
 * `LMS` stands for "**L**acune **M**émorielle **S**ociale" (French for "Social Memory Gap"): see [How it works](#how-it-works)
 
 > [!NOTE]
@@ -79,6 +79,11 @@ It supports the same commands as PyLMS CLI (without the `pylms` prefix), but lim
 ![screenshot of PyLMS Gui](docs/images/screenshot_pylms_gui.png)
 
 Simply write in the input field and hit `<Return>`.
+
+Persistence
+-----------
+
+Data is saved into two JSON files in the working directory: `persons.db` and `relationships.db`.
 
 Development
 ===========

--- a/src/pylms/core.py
+++ b/src/pylms/core.py
@@ -42,6 +42,7 @@ class Person:
         self.firstname = firstname
         self.lastname = lastname
         self._sex = None if sex is None else Person._check_sex(sex)
+        self._tags: list[str] = []
         self.created = Person._check_or_set_created(created)
 
     @staticmethod
@@ -67,6 +68,22 @@ class Person:
     @sex.setter
     def sex(self, sex: Sex) -> None:
         self._sex = Person._check_sex(sex)
+
+    @staticmethod
+    def _ensure_strings(lst: list[any]) -> list[str]:
+        for s in lst:
+            if not isinstance(s, str):
+                raise ValueError("tag must be a str")
+
+        return lst
+
+    @property
+    def tags(self) -> list[str]:
+        return self._tags
+
+    @tags.setter
+    def tags(self, tags: list[str]):
+        self._tags = Person._ensure_strings(tags)
 
     def __eq__(self, other: any) -> bool:
         if isinstance(other, Person):

--- a/src/pylms/gui.py
+++ b/src/pylms/gui.py
@@ -96,6 +96,8 @@ class GuiIOs(IOs):
             person,
             f"({created.year}-{created.month}-{created.day} {created.hour}-{created.minute}-{created.second})",
         )
+        if person.tags:
+            self.gui_manager.write_line("     " + ", ".join(person.tags))
 
     def list_persons(self, resolved_persons: list[(Person, list[Relationship])]) -> None:
         for person, rls in sorted(resolved_persons, key=lambda t: t[0].person_id):

--- a/src/pylms/storage.py
+++ b/src/pylms/storage.py
@@ -27,12 +27,14 @@ class PersonEncoder(json.JSONEncoder):
                     "lastname": o.lastname,
                     "created": str(o.created),
                     "sex": _from_sex(o.sex),
+                    "tags": o.tags,
                 }
             return {
                 "id": o.person_id,
                 "firstname": o.firstname,
                 "created": str(o.created),
                 "sex": _from_sex(o.sex),
+                "tags": o.tags,
             }
         # Let the base class default method raise the TypeError
         return super().default(o)
@@ -58,14 +60,20 @@ def to_person(o: dict) -> Person:
 
     sex: Sex = _to_sex(o)
     if "lastname" in o:
-        return Person(
+        res = Person(
             person_id=o["id"],
             firstname=o["firstname"],
             lastname=o["lastname"],
             created=datetime.fromisoformat(o["created"]),
             sex=sex,
         )
-    return Person(person_id=o["id"], firstname=o["firstname"], created=datetime.fromisoformat(o["created"]), sex=sex)
+    else:
+        res = Person(person_id=o["id"], firstname=o["firstname"], created=datetime.fromisoformat(o["created"]), sex=sex)
+
+    if "tags" in o:
+        res.tags = o["tags"]
+
+    return res
 
 
 def store_persons(persons: list[Person]) -> None:

--- a/tests/pylms/gui_test.py
+++ b/tests/pylms/gui_test.py
@@ -152,6 +152,8 @@ class TestEventListener(unittest.TestCase):
 class TestIOs(unittest.TestCase):
     person1 = Person(person_id=12, firstname="Boo", lastname="Bip", created=datetime(2024, 4, 5, 12, 41, 9))
     person2 = Person(person_id=5, firstname="Acme")
+    person_with_tags = Person(person_id=119, firstname="Mat", created=datetime(2024, 7, 24, 15, 35, 41))
+    person_with_tags.tags = ["toto", "a trooper"]
     rl_definition = RelationshipDefinition(name="related")
 
     def setUp(self):
@@ -177,10 +179,20 @@ class TestIOs(unittest.TestCase):
 
         assert self._get_textarea_text() == "(12)  Boo Bip (2024-4-5 12-41-9)"
 
+    def test_show_person_with_tags_prints_to_textarea(self):
+        self._under_test.show_person(self.person_with_tags)
+
+        assert self._get_textarea_text() == "(119)  Mat (2024-7-24 15-35-41)\n     toto, a trooper"
+
     def test_list_persons_prints_to_textarea(self):
         self._under_test.list_persons([(self.person1, [Relationship(self.person1, self.person2, self.rl_definition)])])
 
         assert self._get_textarea_text() == "(12)  Boo Bip (2024-4-5 12-41-9)\n    -> related (5) Acme"
+
+    def test_list_persons_prints_tags_to_textarea(self):
+        self._under_test.list_persons([(self.person_with_tags, [])])
+
+        assert self._get_textarea_text() == "(119)  Mat (2024-7-24 15-35-41)\n     toto, a trooper"
 
     def test_select_person_not_supported(self):
         with pytest.raises(RuntimeError, match="select_person should not have been called"):

--- a/tests/pylms/storage_test.py
+++ b/tests/pylms/storage_test.py
@@ -85,7 +85,8 @@ def test_store_one_person_with_lastname_no_sex(tmpdir):
     with file.open("r"):
         assert (
             file.read_text()
-            == '[{"id": 1, "firstname": "Jim", "lastname": "Morisson", "created": "2024-04-05 12:41:09", "sex": null}]'
+            == '[{"id": 1, "firstname": "Jim", "lastname": "Morisson", "created": "2024-04-05 12:41:09", "sex": null, '
+            '"tags": []}]'
         )
 
 
@@ -98,7 +99,40 @@ def test_store_one_person_without_lastname(tmpdir):
         store_persons([person])
 
     with file.open("r"):
-        assert file.read_text() == '[{"id": 2, "firstname": "Jim", "created": "2024-04-05 12:41:58", "sex": "M"}]'
+        assert file.read_text() == (
+            '[{"id": 2, "firstname": "Jim", "created": "2024-04-05 12:41:58", "sex": "M", "tags": []}]'
+        )
+
+
+def test_store_one_person_with_tag(tmpdir):
+    file_name = tmpdir + "foo.db"
+    file = Path(file_name)
+    person = Person(2, "Jim", created=datetime(2024, 4, 5, 12, 41, 58), sex=MALE)
+    person.tags = ["acme"]
+
+    with patch("pylms.storage.persons_file_name", file_name):
+        store_persons([person])
+
+    with file.open("r"):
+        assert file.read_text() == (
+            '[{"id": 2, "firstname": "Jim", "created": "2024-04-05 12:41:58", "sex": "M", "tags": ["acme"]}]'
+        )
+
+
+def test_store_one_person_with_tags(tmpdir):
+    file_name = tmpdir + "foo.db"
+    file = Path(file_name)
+    person = Person(2, "Jim", created=datetime(2024, 4, 5, 12, 41, 58), sex=MALE)
+    person.tags = ["acme", "donut", "peanut"]
+
+    with patch("pylms.storage.persons_file_name", file_name):
+        store_persons([person])
+
+    with file.open("r"):
+        assert file.read_text() == (
+            '[{"id": 2, "firstname": "Jim", "created": "2024-04-05 12:41:58", "sex": "M", '
+            '"tags": ["acme", "donut", "peanut"]}]'
+        )
 
 
 def test_store_persons(tmpdir):
@@ -119,9 +153,10 @@ def test_store_persons(tmpdir):
         assert (
             file.read_text() == "["
             r'{"id": 3, "firstname": "S\u00e9bastien", "lastname": "Lesaint", '
-            '"created": "2024-04-05 12:41:58", "sex": null}, '
-            '{"id": 4, "firstname": "Max", "lastname": "Payne", "created": "2024-09-18 21:08:08", "sex": null}, '
-            '{"id": 5, "firstname": "Bob", "created": "2024-09-18 21:08:08", "sex": "F"}'
+            '"created": "2024-04-05 12:41:58", "sex": null, "tags": []}, '
+            '{"id": 4, "firstname": "Max", "lastname": "Payne", "created": "2024-09-18 21:08:08", "sex": null, '
+            '"tags": []}, '
+            '{"id": 5, "firstname": "Bob", "created": "2024-09-18 21:08:08", "sex": "F", "tags": []}'
             "]"
         )
 


### PR DESCRIPTION
# WHY

We need to be able to record details on a person that are not a relationship with another person.

eg.:
* "course escalade CAF"
* "plateau d'Orange"
* …

# WHAT

The command to update a person is modified to allow specifying the tag (or tags) of this person.

There is no effort at this stage to try and prevent duplicates of variations of the same tag across persons.

# HOW

Improve pylms update john from #PYL-21:

* when the Person to update is found (or selected), display:
    ```
    (2) John Doe (2024-4-16 13-11-44)
          cours escalade <-- the existing tags, or no line if no tags yet
    Hit ENTER to update first name and last name, T (or t) to update tags
    CTRL+C to exit
    ```
* If t (or T) is hit, display:
    ```
    Input new tags, separated by comma:
    CTRL+C to exit
    ```
* when ENTER is hit, the list of tags of the person is replaced by the current input, which can be empty (and removes all tags from the person)
* if ENTER is hit directly, behavior is unchanged

Improve pylms

* when a Person has tags, they are displayed on a new line, before the relationships (if any), separated by commas
    ```
    (2) John Doe (2024-4-16 13-11-44)
        escalade CAF adulte, Acme Corp.
        -> Parent/Enfant de (4) Peter
    ```