### PR TITLE
PYL-34 search persons by tags from a single word

### DIFF
--- a/src/pylms/pylms.py
+++ b/src/pylms/pylms.py
@@ -104,12 +104,23 @@ def _search_persons(pattern: str) -> list[Person]:
     return res
 
 
-def _search_match(pattern: str, person: Person) -> bool:
-    pattern = pattern.lower()
+def _search_match_name(pattern, person):
     if person.lastname:
         return pattern in person.lastname.lower() or pattern in person.firstname.lower()
-
     return pattern in person.firstname.lower()
+
+
+def _search_match_tag(pattern, person):
+    if person.tags:
+        for tag in person.tags:
+            if pattern in tag.lower():
+                return True
+    return False
+
+
+def _search_match(pattern: str, person: Person) -> bool:
+    pattern = pattern.lower()
+    return _search_match_name(pattern, person) or _search_match_tag(pattern, person)
 
 
 def store_person(firstname: str) -> None:


### PR DESCRIPTION
# WHY

[PYL-33](https://linear.app/pylms/issue/PYL-33/can-had-tags-to-a-person) added setting and displaying tags. To be any useful, tags need to be searchable.

# WHAT

Search persons with at least one tag containing the provided characters, case-insensitive and accent-sensitive.

# HOW

`pylms foo` searches for person(s) containing `foo` in first name, last name and, we now add, in any of their tags (case insensitive but accent sensitive).